### PR TITLE
Fixing Field Serializer Mapping

### DIFF
--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -156,7 +156,7 @@ final class ModelInfo {
 				}
 				else if (ReflectionUtils.isTypeSerializer(discoveredClass)) {
 					TypeSerializer typeSerializer = (TypeSerializer) discoveredClass.newInstance();
-					mTypeSerializers.put(typeSerializer.getClass(), typeSerializer);
+					mTypeSerializers.put(typeSerializer.getDeserializedType(), typeSerializer);
 				}
 			}
 			catch (ClassNotFoundException e) {

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -125,7 +125,7 @@ public final class SQLiteUtils {
 
 		final Class<?> type = field.getType();
 		final String name = tableInfo.getColumnName(field);
-		final TypeSerializer typeSerializer = Cache.getParserForType(tableInfo.getType());
+		final TypeSerializer typeSerializer = Cache.getParserForType(field.getType());
 		final Column column = field.getAnnotation(Column.class);
 
 		if (typeSerializer != null) {


### PR DESCRIPTION
Two minor issues seem to prevent _SQLiteUtils.createColumnDefinition()_ from creating fields that are not found in the TYPE_MAP but they have their own **Serializer** class.
The attached patch fixed my database definition.
