### PR TITLE
Fixed deserialization with TypeSerializers, BLOB/byte[] support, and DataSetObserver

### DIFF
--- a/src/com/activeandroid/Cache.java
+++ b/src/com/activeandroid/Cache.java
@@ -137,8 +137,8 @@ public final class Cache {
 		return sModelInfo.getTableInfo(type);
 	}
 
-	public static synchronized TypeSerializer getParserForType(Class<?> Type) {
-		return sModelInfo.getTypeSerializer(Type);
+	public static synchronized TypeSerializer getParserForType(Class<?> type) {
+		return sModelInfo.getTypeSerializer(type);
 	}
 
 	public static synchronized String getTableName(Class<? extends Model> type) {

--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -85,6 +85,11 @@ public abstract class Model {
 						// set new object type
 						if (value != null) {
 							fieldType = value.getClass();
+							// check that the serializer returned what it promised
+							if (!fieldType.equals(typeSerializer.getSerializedType())) {
+								Log.w(String.format("TypeSerializer returned wrong type: expected a %s but got a %s",
+										typeSerializer.getSerializedType(), fieldType));
+							}
 						}
 					}
 				}
@@ -182,7 +187,7 @@ public abstract class Model {
 				Object value = null;
 
 				if (typeSerializer != null) {
-					fieldType = typeSerializer.getDeserializedType();
+				  fieldType = typeSerializer.getSerializedType();
 				}
 
 				// TODO: Find a smarter way to do this? This if block is necessary because we

--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -126,6 +126,9 @@ public abstract class Model {
 				else if (fieldType.equals(String.class)) {
 					values.put(fieldName, value.toString());
 				}
+				else if (fieldType.equals(Byte[].class) || fieldType.equals(byte[].class)) {
+					values.put(fieldName, (byte[]) value);
+				}
 				else if (ReflectionUtils.isModel(fieldType)) {
 					values.put(fieldName, ((Model) value).getId());
 				}
@@ -221,6 +224,9 @@ public abstract class Model {
 				}
 				else if (fieldType.equals(String.class)) {
 					value = cursor.getString(columnIndex);
+				}
+				else if (fieldType.equals(Byte[].class) || fieldType.equals(byte[].class)) {
+					value = cursor.getBlob(columnIndex);
 				}
 				else if (ReflectionUtils.isModel(fieldType)) {
 					final long entityId = cursor.getLong(columnIndex);

--- a/src/com/activeandroid/TableInfo.java
+++ b/src/com/activeandroid/TableInfo.java
@@ -24,11 +24,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import android.database.DataSetObservable;
+
 import com.activeandroid.annotation.Column;
 import com.activeandroid.annotation.Table;
 import com.activeandroid.util.Log;
 
-public final class TableInfo {
+public final class TableInfo extends DataSetObservable {
 	//////////////////////////////////////////////////////////////////////////////////////
 	// PRIVATE MEMBERS
 	//////////////////////////////////////////////////////////////////////////////////////

--- a/src/com/activeandroid/serializer/CalendarSerializer.java
+++ b/src/com/activeandroid/serializer/CalendarSerializer.java
@@ -18,15 +18,13 @@ package com.activeandroid.serializer;
 
 import java.util.Calendar;
 
-import com.activeandroid.util.SQLiteUtils.SQLiteType;
-
 public final class CalendarSerializer extends TypeSerializer {
 	public Class<?> getDeserializedType() {
 		return Calendar.class;
 	}
 
-	public SQLiteType getSerializedType() {
-		return SQLiteType.INTEGER;
+	public Class<?> getSerializedType() {
+		return long.class;
 	}
 
 	public Long serialize(Object data) {

--- a/src/com/activeandroid/serializer/SqlDateSerializer.java
+++ b/src/com/activeandroid/serializer/SqlDateSerializer.java
@@ -18,15 +18,13 @@ package com.activeandroid.serializer;
 
 import java.sql.Date;
 
-import com.activeandroid.util.SQLiteUtils.SQLiteType;
-
 public final class SqlDateSerializer extends TypeSerializer {
 	public Class<?> getDeserializedType() {
 		return Date.class;
 	}
 
-	public SQLiteType getSerializedType() {
-		return SQLiteType.INTEGER;
+	public Class<?> getSerializedType() {
+		return long.class;
 	}
 
 	public Long serialize(Object data) {

--- a/src/com/activeandroid/serializer/TypeSerializer.java
+++ b/src/com/activeandroid/serializer/TypeSerializer.java
@@ -16,12 +16,10 @@ package com.activeandroid.serializer;
  * limitations under the License.
  */
 
-import com.activeandroid.util.SQLiteUtils.SQLiteType;
-
 public abstract class TypeSerializer {
 	public abstract Class<?> getDeserializedType();
 
-	public abstract SQLiteType getSerializedType();
+	public abstract Class<?> getSerializedType();
 
 	public abstract Object serialize(Object data);
 

--- a/src/com/activeandroid/serializer/UtilDateSerializer.java
+++ b/src/com/activeandroid/serializer/UtilDateSerializer.java
@@ -18,15 +18,13 @@ package com.activeandroid.serializer;
 
 import java.util.Date;
 
-import com.activeandroid.util.SQLiteUtils.SQLiteType;
-
 public final class UtilDateSerializer extends TypeSerializer {
 	public Class<?> getDeserializedType() {
 		return Date.class;
 	}
 
-	public SQLiteType getSerializedType() {
-		return SQLiteType.INTEGER;
+	public Class<?> getSerializedType() {
+		return long.class;
 	}
 
 	public Long serialize(Object data) {

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -123,15 +123,16 @@ public final class SQLiteUtils {
 	public static String createColumnDefinition(TableInfo tableInfo, Field field) {
 		String definition = null;
 
-		final Class<?> type = field.getType();
+		Class<?> type = field.getType();
 		final String name = tableInfo.getColumnName(field);
 		final TypeSerializer typeSerializer = Cache.getParserForType(field.getType());
 		final Column column = field.getAnnotation(Column.class);
 
 		if (typeSerializer != null) {
-			definition = name + " " + typeSerializer.getSerializedType().toString();
+			type = typeSerializer.getSerializedType();
 		}
-		else if (TYPE_MAP.containsKey(type)) {
+
+		if (TYPE_MAP.containsKey(type)) {
 			definition = name + " " + TYPE_MAP.get(type).toString();
 		}
 		else if (ReflectionUtils.isModel(type)) {

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -62,6 +62,7 @@ public final class SQLiteUtils {
 			put(double.class, SQLiteType.REAL);
 			put(boolean.class, SQLiteType.INTEGER);
 			put(char.class, SQLiteType.TEXT);
+			put(byte[].class, SQLiteType.BLOB);
 			put(Byte.class, SQLiteType.INTEGER);
 			put(Short.class, SQLiteType.INTEGER);
 			put(Integer.class, SQLiteType.INTEGER);
@@ -71,6 +72,7 @@ public final class SQLiteUtils {
 			put(Boolean.class, SQLiteType.INTEGER);
 			put(Character.class, SQLiteType.TEXT);
 			put(String.class, SQLiteType.TEXT);
+			put(Byte[].class, SQLiteType.BLOB);
 		}
 	};
 

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -169,7 +169,7 @@ public final class SQLiteUtils {
 	//////////////////////////////////////////////////////////////////////////////////////
 
 	@SuppressWarnings("unchecked")
-	public static <T extends Model> List<T> processCursor(Class<? extends Model> type, Cursor cursor) {
+	private static <T extends Model> List<T> processCursor(Class<? extends Model> type, Cursor cursor) {
 		final List<T> entities = new ArrayList<T>();
 
 		try {


### PR DESCRIPTION
This is my first pull request to a public project, so I apologize in advance if I haven't followed the expected etiquette. I think 4 commits might be a bit much for one request, but I hope at least some of this is up to the standards of the project.

65a5ddd is just a format cleanup I noticed while working on the other stuff. The other 3 are more major:
1. fd8a5d4 I was implementing a custom Adapter sourced from a From object, and since CursorAdapters get notified by Cursors when backing data changes, I thought it would be nice to have similar functionality here. This implementation isn't ideal, since changes are only monitored at the table level, but tracking the list of results for each query would require a lot more complexity -- this is fairly simple.
2. 8a747a2 Fixes issue #8. The commit description explains the fix. If existing serializers _were_ working, I'm not sure how. I'm very open to any suggestions on how to fix this in a better way. In particular, I couldn't figure out how to fix it without having TypeSerializers provide the java class of their serialized type, since the class-to-SQLiteType mapping isn't one-to-one (e.g. if SQLiteType is REAL, call getFloat() or getDouble()?). In addition to breaking existing code, another problem with this fix is that there is no compile-time checking that the serialized type is valid. The best alternative I could think of is checking TYPE_MAP.containsValue(typeSerializer.getSerializedType()) when registering TypeSerializers on initialization.
3. 7b2e0c5 Byte arrays are trivially serialized using the SQLite BLOB type, so I added the trivial code for that.

Let me know what you think, I would be happy to implement any suggestions.
