### PR TITLE
Fixed Model `equals` method.

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -255,7 +255,7 @@ public abstract class Model {
 	public boolean equals(Object obj) {
 		final Model other = (Model) obj;
 
-		return this.mId != null && (this.mTableInfo.getTableName() == other.mTableInfo.getTableName())
-				&& (this.mId == other.mId);
+		return this.mId != null && (this.mTableInfo.getTableName().equals(other.mTableInfo.getTableName()))
+				&& (this.mId.equals(other.mId));
 	}
 }


### PR DESCRIPTION
`equals` was comparing the memory address of the object members, rather than the values. Changed to use `equals` methods instead of `==`
