### PR TITLE
Add "unique"-clause to column-decorator

### DIFF
--- a/src/com/activeandroid/annotation/Column.java
+++ b/src/com/activeandroid/annotation/Column.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Column {
-	public enum NullConflictAction {
+	public enum ConflictAction {
 		ROLLBACK, ABORT, FAIL, IGNORE, REPLACE
 	}
 
@@ -38,9 +38,13 @@ public @interface Column {
 
 	public boolean notNull() default false;
 
-	public NullConflictAction onNullConflict() default NullConflictAction.FAIL;
+	public ConflictAction onNullConflict() default ConflictAction.FAIL;
 
 	public ForeignKeyAction onDelete() default ForeignKeyAction.NO_ACTION;
 
 	public ForeignKeyAction onUpdate() default ForeignKeyAction.NO_ACTION;
+
+	public boolean unique() default false;
+
+	public ConflictAction onUniqueConflict() default ConflictAction.FAIL;
 }

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -154,6 +154,10 @@ public final class SQLiteUtils {
 				definition += " NOT NULL ON CONFLICT " + column.onNullConflict().toString();
 			}
 
+			if (column.unique()) {
+				definition += " UNIQUE ON CONFLICT " + column.onUniqueConflict().toString();
+			}
+
 			if (FOREIGN_KEYS_SUPPORTED && ReflectionUtils.isModel(type)) {
 				definition += " REFERENCES " + tableInfo.getTableName() + "(Id)";
 				definition += " ON DELETE " + column.onDelete().toString().replace("_", " ");


### PR DESCRIPTION
Allow columns to have a `unique` attribute with `on conflict`-clause.
I renamed `NullConflictAction` to `ConflictAction` as is used for several attributes.
