### PR TITLE
Save and delete callbacks + Testcases

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -59,11 +59,15 @@ public abstract class Model {
 	}
 
 	public final void delete() {
+		onDelete();
+
 		Cache.openDatabase().delete(mTableInfo.getTableName(), "Id=?", new String[] { getId().toString() });
 		Cache.removeEntity(this);
 	}
 
 	public final void save() {
+		onSave();
+
 		final SQLiteDatabase db = Cache.openDatabase();
 		final ContentValues values = new ContentValues();
 
@@ -256,6 +260,18 @@ public abstract class Model {
 
 	protected final <E extends Model> List<E> getMany(Class<? extends Model> type, String foreignKey) {
 		return new Select().from(type).where(Cache.getTableName(type) + "." + foreignKey + "=?", getId()).execute();
+	}
+
+	/**
+	 * Called before {@link save} does any work.
+	 */
+	protected void onSave(){
+	}
+
+	/**
+	 * Called before {@link delete} does any work.
+	 */
+	protected void onDelete(){
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////

--- a/tests/src/com/activeandroid/test/Model/ModelTest.java
+++ b/tests/src/com/activeandroid/test/Model/ModelTest.java
@@ -1,0 +1,87 @@
+package com.activeandroid.test.Model;
+
+/*
+ * Copyright (C) 2010 Michael Pardo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.activeandroid.query.Select;
+import com.activeandroid.test.ActiveAndroidTestCase;
+import com.activeandroid.test.MockModel;
+
+public class ModelTest extends ActiveAndroidTestCase {
+	class CallbackMockModel extends MockModel{
+		public Boolean s=false;
+		public Boolean d=false;
+
+		protected void onSave() {s=true;};
+		protected void onDelete() {d=true;};
+	}
+
+	public void testGetIdAfterSave(){
+		MockModel m=new MockModel();
+		m.MockColumn=42;
+		m.save();
+		assertNotNull("getId() returned null after save()",m.getId());
+
+	}
+
+	public void testGetIdAfterSaveAndSelect(){
+		MockModel m=new MockModel();
+		m.MockColumn=42;
+		m.save();
+		MockModel m2=new Select("MockColumn").from(MockModel.class).where("MockColumn=?", 42).executeSingle();
+		assertEquals(42, m2.MockColumn); //Check
+		assertNotNull("getId() returned null after Select(\"MockColumn\")",m2.getId());
+	}
+
+	public void testOnSave(){
+		CallbackMockModel m=new CallbackMockModel();
+		m.MockColumn=42;
+		assertFalse(m.s);
+		m.save();
+		assertTrue(m.s);
+	}
+
+	public void testThrowingOnSave(){
+		ThrowingCallbackMockModel m=new ThrowingCallbackMockModel();
+		m.ThrowExceptions=true;
+		m.MockColumn=42;
+		try{m.save();}
+		catch (RuntimeException e){}
+		assertNull(m.getId());
+	}
+
+	public void testOnDelete(){
+		CallbackMockModel m=new CallbackMockModel();
+		m.MockColumn=42;
+		m.save();
+		assertFalse(m.d);
+		m.delete();
+		assertTrue(m.d);
+	}
+
+	public void testThrowingOnDelete(){
+		ThrowingCallbackMockModel m=new ThrowingCallbackMockModel();
+		m.MockColumn=42;
+		m.save();
+		ThrowingCallbackMockModel m2=new Select("MockColumn").from(ThrowingCallbackMockModel.class).where("MockColumn=?", 42).executeSingle();
+		assertNotNull(m2);
+		m.ThrowExceptions=true;
+		try{m.delete();}
+		catch (RuntimeException e){}
+		m2=new Select("MockColumn").from(ThrowingCallbackMockModel.class).where("MockColumn=?", 42).executeSingle();
+		assertNotNull(m2);
+	}
+}

--- a/tests/src/com/activeandroid/test/Model/ThrowingCallbackMockModel.java
+++ b/tests/src/com/activeandroid/test/Model/ThrowingCallbackMockModel.java
@@ -1,0 +1,17 @@
+package com.activeandroid.test.Model;
+
+import com.activeandroid.annotation.Column;
+import com.activeandroid.test.MockModel;
+
+class ThrowingCallbackMockModel extends MockModel{
+	@Column(name="MockColumn")
+	public int MockColumn;
+
+	public boolean ThrowExceptions=false;
+
+	public ThrowingCallbackMockModel() {
+	}
+
+	protected void onSave() {if (ThrowExceptions) throw new RuntimeException();};
+	protected void onDelete() {if (ThrowExceptions) throw new RuntimeException();};
+}


### PR DESCRIPTION
Allow subclasses of Model to be notified before save and delete
operations take place and optionally raise an exception if the framework
shouldn’t continue with the operation.
