### PR TITLE
Wrong reference generation / PRAGMA foreign_keys not set

### DIFF
--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -60,6 +60,14 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 	//////////////////////////////////////////////////////////////////////////////////////
 
 	@Override
+	public void onOpen(SQLiteDatabase db) {
+		if (SQLiteUtils.FOREIGN_KEYS_SUPPORTED) {
+			db.execSQL("PRAGMA foreign_keys=ON;");
+			Log.i("Foreign Keys supported. Enabling foreign key features.");
+		}
+	};
+
+	@Override
 	public void onCreate(SQLiteDatabase db) {
 		if (SQLiteUtils.FOREIGN_KEYS_SUPPORTED) {
 			db.execSQL("PRAGMA foreign_keys=ON;");

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -122,6 +122,7 @@ public final class SQLiteUtils {
 				TextUtils.join(", ", definitions));
 	}
 
+	@SuppressWarnings("unchecked")
 	public static String createColumnDefinition(TableInfo tableInfo, Field field) {
 		String definition = null;
 
@@ -162,7 +163,7 @@ public final class SQLiteUtils {
 			}
 
 			if (FOREIGN_KEYS_SUPPORTED && ReflectionUtils.isModel(type)) {
-				definition += " REFERENCES " + tableInfo.getTableName() + "(Id)";
+				definition += " REFERENCES " + Cache.getTableInfo((Class<? extends Model>) type).getTableName() + "(Id)";
 				definition += " ON DELETE " + column.onDelete().toString().replace("_", " ");
 				definition += " ON UPDATE " + column.onUpdate().toString().replace("_", " ");
 			}


### PR DESCRIPTION
PRAGMA foreign_keys=ON needs to be set every time the database is opened.

References are targeted at their own table, not at the referenced table.

``` java
public class Dough extends Model {
    @Column(name = "name", notNull=true, unique=true)
    public String name;
[…]
@Table(name = "Ingredient")
public class Ingredient extends Model {
    @Column(name = "name", notNull=true)
    public String name;

    @Column(name = "dough")
    public Dough dough;

```

should be

``` sql
CREATE TABLE Ingredient (
    Id INTEGER PRIMARY KEY AUTOINCREMENT
    , name TEXT NOT NULL ON CONFLICT FAIL
    , dough INTEGER REFERENCES Dough(Id) ON DELETE NO ACTION ON UPDATE NO ACTION);
```

but 

``` sql
CREATE TABLE Ingredient (
    Id INTEGER PRIMARY KEY AUTOINCREMENT
    , name TEXT NOT NULL ON CONFLICT FAIL
    , dough INTEGER REFERENCES Ingredient(Id) ON DELETE NO ACTION ON UPDATE NO ACTION);
```

is generated.
