### PR TITLE
Allow models extending Model to be instantiated without full ActiveAndroid stack being initialized.

### DIFF
--- a/src/com/activeandroid/ActiveAndroidNotInitialized.java
+++ b/src/com/activeandroid/ActiveAndroidNotInitialized.java
@@ -1,0 +1,7 @@
+package com.activeandroid;
+
+public class ActiveAndroidNotInitialized extends RuntimeException {
+	public ActiveAndroidNotInitialized() {
+		super("ActiveAndroid must be initialized with ActiveAndroid#initialize before interacting with database");
+	}
+}

--- a/src/com/activeandroid/Cache.java
+++ b/src/com/activeandroid/Cache.java
@@ -108,9 +108,6 @@ public final class Cache {
 	// Entity cache
 
 	public static synchronized void addEntity(Model entity) {
-		if (sEntities == null) {
-			return;
-		}
 		sEntities.add(entity);
 	}
 
@@ -137,9 +134,6 @@ public final class Cache {
 	}
 
 	public static synchronized TableInfo getTableInfo(Class<? extends Model> type) {
-		if (sModelInfo == null) {
-			return null;
-		}
 		return sModelInfo.getTableInfo(type);
 	}
 

--- a/src/com/activeandroid/Cache.java
+++ b/src/com/activeandroid/Cache.java
@@ -108,6 +108,9 @@ public final class Cache {
 	// Entity cache
 
 	public static synchronized void addEntity(Model entity) {
+		if (sEntities == null) {
+			return;
+		}
 		sEntities.add(entity);
 	}
 
@@ -134,6 +137,9 @@ public final class Cache {
 	}
 
 	public static synchronized TableInfo getTableInfo(Class<? extends Model> type) {
+		if (sModelInfo == null) {
+			return null;
+		}
 		return sModelInfo.getTableInfo(type);
 	}
 

--- a/src/com/activeandroid/Cache.java
+++ b/src/com/activeandroid/Cache.java
@@ -78,6 +78,7 @@ public final class Cache {
 	}
 
 	public static synchronized void dispose() {
+		checkInitialization();
 		closeDatabase();
 		
 		sEntities = null;
@@ -92,26 +93,33 @@ public final class Cache {
 	// Database access
 
 	public static synchronized SQLiteDatabase openDatabase() {
+		if (sDatabaseHelper == null) {
+			checkInitialization();
+		}
 		return sDatabaseHelper.getWritableDatabase();
 	}
 
 	public static synchronized void closeDatabase() {
+		checkInitialization();
 		sDatabaseHelper.close();
 	}
 
 	// Context access
 
 	public static Context getContext() {
+		checkInitialization();
 		return sContext;
 	}
 
 	// Entity cache
 
 	public static synchronized void addEntity(Model entity) {
+		checkInitialization();
 		sEntities.add(entity);
 	}
 
 	public static synchronized Model getEntity(Class<? extends Model> type, long id) {
+		checkInitialization();
 		for (Model entity : sEntities) {
 			if (entity != null && entity.getClass() != null && entity.getClass() == type && entity.getId() != null
 					&& entity.getId() == id) {
@@ -124,24 +132,35 @@ public final class Cache {
 	}
 
 	public static synchronized void removeEntity(Model entity) {
+		checkInitialization();
 		sEntities.remove(entity);
 	}
 
 	// Model cache
 
 	public static synchronized Collection<TableInfo> getTableInfos() {
+		checkInitialization();
 		return sModelInfo.getTableInfos();
 	}
 
 	public static synchronized TableInfo getTableInfo(Class<? extends Model> type) {
+		checkInitialization();
 		return sModelInfo.getTableInfo(type);
 	}
 
 	public static synchronized TypeSerializer getParserForType(Class<?> type) {
+		checkInitialization();
 		return sModelInfo.getTypeSerializer(type);
 	}
 
 	public static synchronized String getTableName(Class<? extends Model> type) {
+		checkInitialization();
 		return sModelInfo.getTableInfo(type).getTableName();
+	}
+
+	private static void checkInitialization() {
+		if (!sIsInitialized) {
+			throw new ActiveAndroidNotInitialized();
+		}
 	}
 }

--- a/src/com/activeandroid/Cache.java
+++ b/src/com/activeandroid/Cache.java
@@ -65,9 +65,9 @@ public final class Cache {
 
 		sEntities = new HashSet<Model>();
 
-		openDatabase();
-
 		sIsInitialized = true;
+
+		openDatabase();
 
 		Log.v("ActiveAndroid initialized succesfully.");
 	}
@@ -93,9 +93,7 @@ public final class Cache {
 	// Database access
 
 	public static synchronized SQLiteDatabase openDatabase() {
-		if (sDatabaseHelper == null) {
-			checkInitialization();
-		}
+    checkInitialization();
 		return sDatabaseHelper.getWritableDatabase();
 	}
 

--- a/tests/src/com/activeandroid/test/LazyInitializeTest.java
+++ b/tests/src/com/activeandroid/test/LazyInitializeTest.java
@@ -1,0 +1,21 @@
+package com.activeandroid.test;
+
+import android.test.AndroidTestCase;
+import com.activeandroid.ActiveAndroidNotInitialized;
+
+public class LazyInitializeTest extends AndroidTestCase {
+	public void testInitializeDoesNotThrow() throws Exception {
+		new MockModel();
+	}
+
+	public void testInteractionRequiringDatabaseThrows() {
+		boolean expectedExceptionThrown = false;
+		try {
+			new MockModel().save();
+		} catch (ActiveAndroidNotInitialized e) {
+			expectedExceptionThrown = true;
+		}
+
+		assertTrue(expectedExceptionThrown);
+	}
+}


### PR DESCRIPTION
To unit test my classes that extend `Model`, I need to be able to instantiate them outside of the context where `Application` is available to pass into `ActiveAndroid#initialize`. I added two null checks in the `Cache` class to allow the models to be instantiated as POJOs. I would welcome feedback on other ways to allow this functionality.
