### PR TITLE
Robolectric model scan for maven tests

### DIFF
--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -105,8 +105,8 @@ final class ModelInfo {
 
 			while (resources.hasMoreElements()) {
 				String path = resources.nextElement().getFile();
-				if (path.contains("bin")) {
-					paths.add(path);
+				if (path.contains("bin") || path.contains("classes")) {
+						paths.add(path);
 				}
 			}
 		}


### PR DESCRIPTION
This scan path tweak will allow Robolectric tests in maven to find model classes. [This stackoverflow issue](http://stackoverflow.com/questions/16324822/testing-activeandroid-with-robolectric) is the motivation.
