### PR TITLE
Fix pom.xml for building with Maven

### DIFF
--- a/pom-child.xml
+++ b/pom-child.xml
@@ -23,6 +23,7 @@
     <groupId>com.activeandroid</groupId>
     <artifactId>activeandroid-parent</artifactId>
     <version>3.1-SNAPSHOT</version>
+    <relativePath>./pom.xml</relativePath>
   </parent>
 
     <scm>

--- a/pom-child.xml
+++ b/pom-child.xml
@@ -51,6 +51,11 @@
             <version>${platform.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>support-v4</artifactId>
+            <version>${platform.support-version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -36,7 +36,7 @@
       <groupId>com.activeandroid</groupId>
       <artifactId>activeandroid</artifactId>
       <type>jar</type>
-      <version>1.0-SNAPSHOT</version>
+      <version>3.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
`mvn clean install` was failing due to the support lib being missing as a dependency, and the incorrect version of ActiveAndroid being used as a dependency for the tests module.
