### PR TITLE
Support ListView: ID column name = "_ID"

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -22,6 +22,7 @@ import java.util.List;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.provider.BaseColumns;
 
 import com.activeandroid.annotation.Column;
 import com.activeandroid.content.ContentProvider;
@@ -33,11 +34,16 @@ import com.activeandroid.util.ReflectionUtils;
 
 @SuppressWarnings("unchecked")
 public abstract class Model {
+	
+	public interface Columns {
+		static final String ID = BaseColumns._ID; 
+	}
+	
 	//////////////////////////////////////////////////////////////////////////////////////
 	// PRIVATE MEMBERS
 	//////////////////////////////////////////////////////////////////////////////////////
 
-	@Column(name = "Id")
+	@Column(name = Columns.ID)
 	private Long mId = null;
 
 	private TableInfo mTableInfo;
@@ -60,7 +66,7 @@ public abstract class Model {
 	}
 
 	public final void delete() {
-		Cache.openDatabase().delete(mTableInfo.getTableName(), "Id=?", new String[] { getId().toString() });
+		Cache.openDatabase().delete(mTableInfo.getTableName(), Columns.ID + "=?", new String[] { getId().toString() });
 		Cache.removeEntity(this);
 
 		Cache.getContext().getContentResolver()
@@ -151,7 +157,7 @@ public abstract class Model {
 			mId = db.insert(mTableInfo.getTableName(), null, values);
 		}
 		else {
-			db.update(mTableInfo.getTableName(), values, "Id=" + mId, null);
+			db.update(mTableInfo.getTableName(), values, Columns.ID + "=" + mId, null);
 		}
 
 		Cache.getContext().getContentResolver()
@@ -161,11 +167,11 @@ public abstract class Model {
 	// Convenience methods
 
 	public static void delete(Class<? extends Model> type, long id) {
-		new Delete().from(type).where("Id=?", id).execute();
+		new Delete().from(type).where(Columns.ID + "=?", id).execute();
 	}
 
 	public static <T extends Model> T load(Class<T> type, long id) {
-		return new Select().from(type).where("Id=?", id).executeSingle();
+		return new Select().from(type).where(Columns.ID + "=?", id).executeSingle();
 	}
 
 	// Model population
@@ -232,7 +238,7 @@ public abstract class Model {
 
 					Model entity = Cache.getEntity(entityType, entityId);
 					if (entity == null) {
-						entity = new Select().from(entityType).where("Id=?", entityId).executeSingle();
+						entity = new Select().from(entityType).where(Columns.ID + "=?", entityId).executeSingle();
 					}
 
 					value = entity;

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -16,6 +16,8 @@ package com.activeandroid.util;
  * limitations under the License.
  */
 
+import static com.activeandroid.Model.Columns.ID;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -150,7 +152,7 @@ public final class SQLiteUtils {
 				definition += "(" + column.length() + ")";
 			}
 
-			if (name.equals("Id")) {
+			if (name.equals(ID)) {
 				definition += " PRIMARY KEY AUTOINCREMENT";
 			}
 
@@ -163,7 +165,7 @@ public final class SQLiteUtils {
 			}
 
 			if (FOREIGN_KEYS_SUPPORTED && ReflectionUtils.isModel(type)) {
-				definition += " REFERENCES " + Cache.getTableInfo((Class<? extends Model>) type).getTableName() + "(Id)";
+				definition += " REFERENCES " + Cache.getTableInfo((Class<? extends Model>) type).getTableName() + "(" + ID + ")";
 				definition += " ON DELETE " + column.onDelete().toString().replace("_", " ");
 				definition += " ON UPDATE " + column.onUpdate().toString().replace("_", " ");
 			}

--- a/tests/src/com/activeandroid/test/query/FromTest.java
+++ b/tests/src/com/activeandroid/test/query/FromTest.java
@@ -16,6 +16,8 @@ package com.activeandroid.test.query;
  * limitations under the License.
  */
 
+import static com.activeandroid.Model.Columns.ID;
+
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Table;
 import com.activeandroid.query.From;
@@ -52,53 +54,53 @@ public class FromTest extends SqlableTestCase {
 	}
 	
 	public void testOrderBy() {
-		assertSqlEquals(SELECT_PREFIX + "ORDER BY Id DESC",
-				from().orderBy("Id DESC"));
+		assertSqlEquals(SELECT_PREFIX + "ORDER BY " + ID + " DESC",
+				from().orderBy(ID + " DESC"));
 	}
 	
 	public void testWhereNoArguments() {
-		assertSqlEquals(SELECT_PREFIX + "WHERE Id = 5",
-				from().where("Id = 5"));
+		assertSqlEquals(SELECT_PREFIX + "WHERE " + ID + " = 5",
+				from().where(ID + " = 5"));
 		
-		assertSqlEquals(SELECT_PREFIX + "WHERE Id = 5",
-				from().where("Id = 1").where("Id = 2").where("Id = 5"));
+		assertSqlEquals(SELECT_PREFIX + "WHERE " + ID + " = 5",
+				from().where(ID + " = 1").where("" + ID + " = 2").where("" + ID + " = 5"));
 	}
 	
 	public void testWhereWithArguments() {
-		From query = from().where("Id = ?", 5);
+		From query = from().where(ID + " = ?", 5);
 		assertArrayEquals(query.getArguments(), "5");
-		assertSqlEquals(SELECT_PREFIX + "WHERE Id = ?",
+		assertSqlEquals(SELECT_PREFIX + "WHERE " + ID + " = ?",
 				query);
 		
-		query = from().where("Id > ? AND Id < ?", 5, 10);
+		query = from().where(ID + " > ? AND " + ID + " < ?", 5, 10);
 		assertArrayEquals(query.getArguments(), "5", "10");
-		assertSqlEquals(SELECT_PREFIX + "WHERE Id > ? AND Id < ?",
+		assertSqlEquals(SELECT_PREFIX + "WHERE " + ID + " > ? AND " + ID + " < ?",
 				query);
 		
 		query = from()
-				.where("Id != ?", 10)
-				.where("Id IN (?, ?, ?)", 5, 10, 15)
-				.where("Id > ? AND Id < ?", 5, 10);
+				.where(ID + " != ?", 10)
+				.where(ID + " IN (?, ?, ?)", 5, 10, 15)
+				.where(ID + " > ? AND " + ID + " < ?", 5, 10);
 		assertArrayEquals(query.getArguments(), "5", "10");
-		assertSqlEquals(SELECT_PREFIX + "WHERE Id > ? AND Id < ?",
+		assertSqlEquals(SELECT_PREFIX + "WHERE " + ID + " > ? AND " + ID + " < ?",
 				query);
 	}
 	
 	public void testSingleJoin() {
-		assertSqlEquals(SELECT_PREFIX + "JOIN JoinModel ON MockModel.Id = JoinModel.Id",
-				from().join(JoinModel.class).on("MockModel.Id = JoinModel.Id"));
+		assertSqlEquals(SELECT_PREFIX + "JOIN JoinModel ON MockModel." + ID + " = JoinModel." + ID + "",
+				from().join(JoinModel.class).on("MockModel." + ID + " = JoinModel." + ID + ""));
 		
-		assertSqlEquals(SELECT_PREFIX + "AS a JOIN JoinModel AS b ON a.Id = b.Id",
-				from().as("a").join(JoinModel.class).as("b").on("a.Id = b.Id"));
+		assertSqlEquals(SELECT_PREFIX + "AS a JOIN JoinModel AS b ON a." + ID + " = b." + ID + "",
+				from().as("a").join(JoinModel.class).as("b").on("a." + ID + " = b." + ID + ""));
 		
-		assertSqlEquals(SELECT_PREFIX + "JOIN JoinModel USING (Id, other)",
-				from().join(JoinModel.class).using("Id", "other"));
+		assertSqlEquals(SELECT_PREFIX + "JOIN JoinModel USING (" + ID + ", other)",
+				from().join(JoinModel.class).using(ID + "", "other"));
 	}
 	
 	public void testJoins() {
-		assertSqlEquals(SELECT_PREFIX + "JOIN JoinModel ON Id JOIN JoinModel2 ON Id",
-				from().join(JoinModel.class).on("Id")
-				.join(JoinModel2.class).on("Id"));
+		assertSqlEquals(SELECT_PREFIX + "JOIN JoinModel ON " + ID + " JOIN JoinModel2 ON " + ID + "",
+				from().join(JoinModel.class).on(ID + "")
+				.join(JoinModel2.class).on(ID + ""));
 	}
 	
 	public void testJoinTypes() {
@@ -111,43 +113,43 @@ public class FromTest extends SqlableTestCase {
 	}
 	
 	public void testGroupByHaving() {
-		assertSqlEquals(SELECT_PREFIX + "GROUP BY Id",
-				from().groupBy("Id"));
-		assertSqlEquals(SELECT_PREFIX + "GROUP BY Id HAVING Id = 1",
-				from().groupBy("Id").having("Id = 1"));
-		assertSqlEquals(SELECT_PREFIX + "GROUP BY Id HAVING Id = 1",
-				from().having("Id = 1").groupBy("Id"));
+		assertSqlEquals(SELECT_PREFIX + "GROUP BY " + ID + "",
+				from().groupBy(ID + ""));
+		assertSqlEquals(SELECT_PREFIX + "GROUP BY " + ID + " HAVING " + ID + " = 1",
+				from().groupBy(ID + "").having("" + ID + " = 1"));
+		assertSqlEquals(SELECT_PREFIX + "GROUP BY " + ID + " HAVING " + ID + " = 1",
+				from().having(ID + " = 1").groupBy("" + ID + ""));
 	}
 	
 	public void testAll() {
-		final String expectedSql = SELECT_PREFIX + "AS a JOIN JoinModel USING (Id) WHERE Id > 5 GROUP BY Id HAVING Id < 10 LIMIT 5 OFFSET 10";
+		final String expectedSql = SELECT_PREFIX + "AS a JOIN JoinModel USING (" + ID + ") WHERE " + ID + " > 5 GROUP BY " + ID + " HAVING " + ID + " < 10 LIMIT 5 OFFSET 10";
 		
 		// Try a few different orderings, shouldn't change the output
 		assertSqlEquals(expectedSql,
 				from()
 					.as("a")
-					.where("Id > 5")
-					.join(JoinModel.class).using("Id")
-					.groupBy("Id")
-					.having("Id < 10")
+					.where(ID + " > 5")
+					.join(JoinModel.class).using(ID + "")
+					.groupBy(ID + "")
+					.having(ID + " < 10")
 					.limit(5)
 					.offset(10));
 		assertSqlEquals(expectedSql,
 				from()
 					.offset(10)
-					.having("Id < 10")
-					.join(JoinModel.class).using("Id")
+					.having(ID + " < 10")
+					.join(JoinModel.class).using(ID + "")
 					.limit(5)
 					.as("a")
-					.where("Id > 5")
-					.groupBy("Id"));
+					.where(ID + " > 5")
+					.groupBy(ID + ""));
 		assertSqlEquals(expectedSql,
 				from()
-					.join(JoinModel.class).using("Id")
+					.join(JoinModel.class).using(ID + "")
 					.offset(10)
-					.having("Id < 10")
-					.where("Id > 5")
-					.groupBy("Id")
+					.having(ID + " < 10")
+					.where(ID + " > 5")
+					.groupBy(ID + "")
 					.limit(5)
 					.as("a"));
 	}

--- a/tests/src/com/activeandroid/test/query/UpdateTest.java
+++ b/tests/src/com/activeandroid/test/query/UpdateTest.java
@@ -16,6 +16,8 @@ package com.activeandroid.test.query;
  * limitations under the License.
  */
 
+import static com.activeandroid.Model.Columns.ID;
+
 import com.activeandroid.query.Set;
 import com.activeandroid.query.Update;
 import com.activeandroid.test.MockModel;
@@ -28,31 +30,31 @@ public class UpdateTest extends SqlableTestCase {
 	}
 	
 	public void testUpdateSet() {
-		assertSqlEquals(UPDATE_PREFIX + "SET Id = 5 ",
-				update().set("Id = 5"));
+		assertSqlEquals(UPDATE_PREFIX + "SET " + ID + " = 5 ",
+				update().set(ID + " = 5"));
 	}
 	
 	public void testUpdateWhereNoArguments() {
-		assertSqlEquals(UPDATE_PREFIX + "SET Id = 5 WHERE Id = 1 ",
+		assertSqlEquals(UPDATE_PREFIX + "SET " + ID + " = 5 WHERE " + ID + " = 1 ",
 				update()
-					.set("Id = 5")
-					.where("Id = 1"));
+					.set(ID + " = 5")
+					.where(ID + " = 1"));
 	}
 	
 	public void testUpdateWhereWithArguments() {
 		Set set = update()
-				.set("Id = 5")
-				.where("Id = ?", 1);
+				.set(ID + " = 5")
+				.where(ID + " = ?", 1);
 		assertArrayEquals(set.getArguments(), "1");
-		assertSqlEquals(UPDATE_PREFIX + "SET Id = 5 WHERE Id = ? ",
+		assertSqlEquals(UPDATE_PREFIX + "SET " + ID + " = 5 WHERE " + ID + " = ? ",
 				set);
 		
 		set = update()
-				.set("Id = 5")
-				.where("Id = ?", 1)
-				.where("Id IN (?, ?, ?)", 5, 4, 3);
+				.set(ID + " = 5")
+				.where(ID + " = ?", 1)
+				.where(ID + " IN (?, ?, ?)", 5, 4, 3);
 		assertArrayEquals(set.getArguments(), "5", "4", "3");
-		assertSqlEquals(UPDATE_PREFIX + "SET Id = 5 WHERE Id IN (?, ?, ?) ",
+		assertSqlEquals(UPDATE_PREFIX + "SET " + ID + " = 5 WHERE " + ID + " IN (?, ?, ?) ",
 				set);
 	}
 	


### PR DESCRIPTION
In order to use the rows from a `Cursor` in a `ListView` each row must be identified by a column named **_ID** (see [Content Provider Basics](http://developer.android.com/intl/de/guide/topics/providers/content-provider-basics.html#DisplayResults)). To simplify things it would be nice if the primary key for each `Model` would be named **_ID** by default. I added an interface called `Columns` to `Model` which contains a constant `ID` which is an alias for `android.provider.BaseColumns._ID`. I extend this interface in my subclasses of `Model` to keep track of the names of their additional columns. This reduces the usage of [magic strings](http://en.wikipedia.org/wiki/Magic_string), too.
