### PR TITLE
Use StringBuilder instead of String to createColumnDefinition

### DIFF
--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -124,7 +124,7 @@ public final class SQLiteUtils {
 
 	@SuppressWarnings("unchecked")
 	public static String createColumnDefinition(TableInfo tableInfo, Field field) {
-		String definition = null;
+		StringBuilder definition = new StringBuilder();
 
 		Class<?> type = field.getType();
 		final String name = tableInfo.getColumnName(field);
@@ -136,43 +136,57 @@ public final class SQLiteUtils {
 		}
 
 		if (TYPE_MAP.containsKey(type)) {
-			definition = name + " " + TYPE_MAP.get(type).toString();
+			definition.append(name);
+			definition.append(" ");
+			definition.append(TYPE_MAP.get(type).toString());
 		}
 		else if (ReflectionUtils.isModel(type)) {
-			definition = name + " " + SQLiteType.INTEGER.toString();
+			definition.append(name);
+			definition.append(" ");
+			definition.append(SQLiteType.INTEGER.toString());
 		}
 		else if (ReflectionUtils.isSubclassOf(type, Enum.class)) {
-			definition = name + " " + SQLiteType.TEXT.toString();
+			definition.append(name);
+			definition.append(" ");
+			definition.append(SQLiteType.TEXT.toString());
 		}
 
-		if (definition != null) {
+		if (!TextUtils.isEmpty(definition)) {
 			if (column.length() > -1) {
-				definition += "(" + column.length() + ")";
+				definition.append("(");
+				definition.append(column.length());
+				definition.append(")");
 			}
 
 			if (name.equals("Id")) {
-				definition += " PRIMARY KEY AUTOINCREMENT";
+				definition.append(" PRIMARY KEY AUTOINCREMENT");
 			}
 
 			if (column.notNull()) {
-				definition += " NOT NULL ON CONFLICT " + column.onNullConflict().toString();
+				definition.append(" NOT NULL ON CONFLICT ");
+				definition.append(column.onNullConflict().toString());
 			}
 
 			if (column.unique()) {
-				definition += " UNIQUE ON CONFLICT " + column.onUniqueConflict().toString();
+				definition.append(" UNIQUE ON CONFLICT ");
+				definition.append(column.onUniqueConflict().toString());
 			}
 
 			if (FOREIGN_KEYS_SUPPORTED && ReflectionUtils.isModel(type)) {
-				definition += " REFERENCES " + Cache.getTableInfo((Class<? extends Model>) type).getTableName() + "(Id)";
-				definition += " ON DELETE " + column.onDelete().toString().replace("_", " ");
-				definition += " ON UPDATE " + column.onUpdate().toString().replace("_", " ");
+				definition.append(" REFERENCES ");
+				definition.append(Cache.getTableInfo((Class<? extends Model>) type).getTableName());
+				definition.append("(Id)");
+				definition.append(" ON DELETE ");
+				definition.append(column.onDelete().toString().replace("_", " "));
+				definition.append(" ON UPDATE ");
+				definition.append(column.onUpdate().toString().replace("_", " "));
 			}
 		}
 		else {
 			Log.e("No type mapping for: " + type.toString());
 		}
 
-		return definition;
+		return definition.toString();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Use a StringBuilder instead a normal string in createColumnDefinition
method, avoid many strings in memory.
