### PR TITLE
Do not assume that toString() for an entity has not been overwritten.

### DIFF
--- a/src/com/activeandroid/Cache.java
+++ b/src/com/activeandroid/Cache.java
@@ -116,16 +116,24 @@ public final class Cache {
 
 	// Entity cache
 
+	public static String getIdentifier(Class<? extends Model> type, Long id) {
+		return getTableName(type) + "@" + id;
+	}
+
+	public static String getIdentifier(Model entity) {
+		return getIdentifier(entity.getClass(), entity.getId());
+	}
+
 	public static synchronized void addEntity(Model entity) {
-		sEntities.put(entity.toString(), entity);
+		sEntities.put(getIdentifier(entity), entity);
 	}
 
 	public static synchronized Model getEntity(Class<? extends Model> type, long id) {
-		return sEntities.get(getTableName(type) + "@" + id);
+		return sEntities.get(getIdentifier(type, id));
 	}
 
 	public static synchronized void removeEntity(Model entity) {
-		sEntities.remove(entity.toString());
+		sEntities.remove(getIdentifier(entity));
 	}
 
 	// Model cache


### PR DESCRIPTION
I found this issue while debugging my code and was confused that .toString() kept being called on my objects. I usually overwrite .toString() to return some sensible representation of my objects which can also be useful while debugging. This means that .toString() can be quite slow or cause null-reference exceptions at some points.

The Cache class currently uses the .toString() method as the key when adding it to the entity cache and 'getTableName(type) + "@" + id' on look-up.

This assumes that .toString() and the concatenated string are always the same, which is obviously no longer the case once a derived class overwrites .toString(). This commit fixes this, by using an entity's table name and its ID as the key. This should keep others (like me :) from unintentionally breaking caching.

The look-up will still fail once an entity has been persisted (which causes its ID to change from NULL to some number), is this intended? (Sorry, haven't had time to dig deeper, maybe I'm missing something).
