### PR TITLE
Update README.md to include https in waffle.io badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Stories in Ready](http://badge.waffle.io/pardom/ActiveAndroid.png)](http://waffle.io/pardom/ActiveAndroid)  
+[![Stories in Ready](https://badge.waffle.io/pardom/ActiveAndroid.png)](http://waffle.io/pardom/ActiveAndroid)  
 # ActiveAndroid
 
 ActiveAndroid is an active record style ORM ([object relational mapper](http://en.wikipedia.org/wiki/Object-relational_mapping)). What does that mean exactly? Well, ActiveAndroid allows you to save and retrieve SQLite database records without ever writing a single SQL statement. Each database record is wrapped neatly into a class with methods like _save()_ and _delete()_.


### PR DESCRIPTION
GitHub caches non-encrypted images, now your waffle.io badge will always be up to date
