### PR TITLE
Equals() should be type safe, null-aware and hashcode() should be overridden

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -291,21 +291,20 @@ public abstract class Model {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof Model) {
+		if (obj instanceof Model && this.mId != null) {
 			final Model other = (Model) obj;
 
-			return ((this.mId != null && this.mId.equals(other.mId)) //ids not null and match
-							|| (this.mId == null && other.mId == null)) // or both ids are null
+			return this.mId.equals(other.mId)							
 							&& (this.mTableInfo.getTableName().equals(other.mTableInfo.getTableName()));
 		} else {
-			return false;
+			return this == obj;
 		}
 	}
 
 	@Override
 	public int hashCode() {
 		int hash = HASH_PRIME;
-		hash += mId == null ? 0 : HASH_PRIME * mId.hashCode();
+		hash += HASH_PRIME * (mId == null ? super.hashCode() : mId.hashCode()); //if id is null, use Object.hashCode()
 		hash += HASH_PRIME * mTableInfo.getTableName().hashCode();
 		return hash; //To change body of generated methods, choose Tools | Templates.
 	}

--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -33,6 +33,10 @@ import com.activeandroid.util.ReflectionUtils;
 
 @SuppressWarnings("unchecked")
 public abstract class Model {
+
+	/** Prime number used for hashcode() implementation. */
+	private static final int HASH_PRIME = 739;
+
 	//////////////////////////////////////////////////////////////////////////////////////
 	// PRIVATE MEMBERS
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -284,9 +288,22 @@ public abstract class Model {
 
 	@Override
 	public boolean equals(Object obj) {
-		final Model other = (Model) obj;
+		if (obj instanceof Model) {
+			final Model other = (Model) obj;
 
-		return this.mId != null && (this.mTableInfo.getTableName().equals(other.mTableInfo.getTableName()))
-				&& (this.mId.equals(other.mId));
+			return ((this.mId != null && this.mId.equals(other.mId)) //ids not null and match
+							|| (this.mId == null && other.mId == null)) // or both ids are null
+							&& (this.mTableInfo.getTableName().equals(other.mTableInfo.getTableName()));
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = HASH_PRIME;
+		hash += mId == null ? 0 : HASH_PRIME * mId.hashCode();
+		hash += HASH_PRIME * mTableInfo.getTableName().hashCode();
+		return hash; //To change body of generated methods, choose Tools | Templates.
 	}
 }

--- a/tests/src/com/activeandroid/test/ModelTest.java
+++ b/tests/src/com/activeandroid/test/ModelTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2013 Vojtech Sigler.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.activeandroid.test;
+
+import com.activeandroid.Model;
+import com.activeandroid.annotation.Table;
+import java.util.HashSet;
+import java.util.Set;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+
+/**
+ * Simple test now covering equals and hashcode methods.
+ */
+public class ModelTest extends ActiveAndroidTestCase {
+
+	/**
+	 * Equals should be type-safe.
+	 */	
+	public void testEqualsNonModel() {
+		MockModel model = new MockModel();
+
+		assertFalse(model.equals("Dummy"));
+	}
+
+	/**
+	 * Equals should not be true for different model classes.
+	 */	
+	public void testEqualsDifferentModel() {
+		Model model1 = new MockModel();
+		Model model2 = new AnotherMockModel();
+
+		assertFalse(model1.equals(model2));
+	}
+
+	/**
+	 * Equals should not consider two new objects of the same
+	 * class non-equal.
+	 */	
+	public void testEqualsOnNew() {
+		MockModel model1 = new MockModel();
+		MockModel model2 = new MockModel();
+
+		assertTrue(model1.equals(model2));
+		assertTrue(model2.equals(model1));
+	}
+
+	/**
+	 * Two different rows in a table should not be equal (different ids).
+	 */	
+	public void testEqualsDifferentRows() {
+		MockModel model1 = new MockModel();
+		MockModel model2 = new MockModel();
+
+		model1.save();
+		model2.save();
+
+		assertFalse(model1.equals(model2));
+		assertFalse(model2.equals(model1));
+	}
+
+	/**
+	 * Tests hashcode for new instances.
+	 */	
+	public void testHashCode() {
+		Set<Model> set = new HashSet<Model>();
+		Model m1 = new MockModel();
+		Model m2 = new MockModel();
+		Model m3 = new AnotherMockModel();
+
+		assertEquals(m1.hashCode(), m2.hashCode());
+		set.add(m1);
+		set.add(m2);
+		assertEquals(1, set.size());
+
+		assertFalse(m1.hashCode() == m3.hashCode());
+		set.add(m3);
+		assertEquals(2, set.size());
+	}
+
+	/**
+	 * Two rows in a table should have different hashcodes.
+	 */
+	public void testHashCodeDifferentRows() {
+		Set<Model> set = new HashSet<Model>();
+		Model m1 = new MockModel();
+		Model m2 = new MockModel();
+
+		m1.save();
+		m2.save();
+
+		assertFalse(m1.hashCode() == m2.hashCode());
+		set.add(m1);
+		set.add(m2);
+		assertEquals(2, set.size());
+	}
+
+	/**
+	 * Mock model as we need 2 different model classes.
+	 */
+	@Table(name = "AnotherMockTable")
+	public static class AnotherMockModel extends Model {}
+}

--- a/tests/src/com/activeandroid/test/ModelTest.java
+++ b/tests/src/com/activeandroid/test/ModelTest.java
@@ -35,6 +35,7 @@ public class ModelTest extends ActiveAndroidTestCase {
 		MockModel model = new MockModel();
 
 		assertFalse(model.equals("Dummy"));
+		assertFalse(model.equals(null));
 	}
 
 	/**
@@ -48,15 +49,16 @@ public class ModelTest extends ActiveAndroidTestCase {
 	}
 
 	/**
-	 * Equals should not consider two new objects of the same
-	 * class non-equal.
+	 * A new object does not have PK assigned yet,
+	 * therefore by default it is equal only to itself.
 	 */	
 	public void testEqualsOnNew() {
 		MockModel model1 = new MockModel();
 		MockModel model2 = new MockModel();
 
-		assertTrue(model1.equals(model2));
-		assertTrue(model2.equals(model1));
+		assertFalse(model1.equals(model2));
+		assertFalse(model2.equals(model1));
+		assertTrue(model1.equals(model1));//equal only to itself
 	}
 
 	/**
@@ -65,12 +67,18 @@ public class ModelTest extends ActiveAndroidTestCase {
 	public void testEqualsDifferentRows() {
 		MockModel model1 = new MockModel();
 		MockModel model2 = new MockModel();
+		MockModel model3;
 
 		model1.save();
 		model2.save();
+		model3 = Model.load(MockModel.class, model1.getId());
 
 		assertFalse(model1.equals(model2));
 		assertFalse(model2.equals(model1));
+		assertTrue(model1.equals(model3));
+		assertTrue(model1.equals(model3));
+		assertFalse(model3.equals(model2));
+		assertFalse(model2.equals(model3));
 	}
 
 	/**
@@ -82,14 +90,14 @@ public class ModelTest extends ActiveAndroidTestCase {
 		Model m2 = new MockModel();
 		Model m3 = new AnotherMockModel();
 
-		assertEquals(m1.hashCode(), m2.hashCode());
+		assertFalse(m1.hashCode() == m2.hashCode()); // hashes for unsaved models must not match
 		set.add(m1);
 		set.add(m2);
-		assertEquals(1, set.size());
+		assertEquals(2, set.size()); //try in a set
 
 		assertFalse(m1.hashCode() == m3.hashCode());
 		set.add(m3);
-		assertEquals(2, set.size());
+		assertEquals(3, set.size());
 	}
 
 	/**
@@ -99,13 +107,17 @@ public class ModelTest extends ActiveAndroidTestCase {
 		Set<Model> set = new HashSet<Model>();
 		Model m1 = new MockModel();
 		Model m2 = new MockModel();
+		Model m3;
 
 		m1.save();
 		m2.save();
+		m3 = Model.load(MockModel.class, m1.getId());
 
+		assertEquals(m1.hashCode(), m3.hashCode());
 		assertFalse(m1.hashCode() == m2.hashCode());
 		set.add(m1);
 		set.add(m2);
+		set.add(m3);
 		assertEquals(2, set.size());
 	}
 


### PR DESCRIPTION
When playing around with ActiveAndroid I found weird behavior of the Model.equals() method.
- For two new blank models, equals would not consider them equal.
- Equals would throw ClassCastException when compared to anything else than another model.
- Equals against null throws NullPointerException

After looking at the equals method, it does not check type or null/notnull of the other object. Also, once a model has null id (not yet saved), it is automatically not equal to anything, which I also see as a bug. There is also a missing hashcode override, so models cannot be used in e.g. hash sets.

The proposed changes fix these problems - overridden hashcode, type safe and null-aware equals and null id does not automatically mean not equal to anything. I've also added a test for this behavior.
