### PR TITLE
Add a new constructor for making Model instances on non-android systems

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -45,10 +45,18 @@ public abstract class Model {
 	//////////////////////////////////////////////////////////////////////////////////////
 	// CONSTRUCTORS
 	//////////////////////////////////////////////////////////////////////////////////////
-
+	
 	public Model() {
-		mTableInfo = Cache.getTableInfo(getClass());
-	}
+        	this(true);
+        }
+
+    	public Model(boolean instanciatedOnAndroid) {
+        	// to allow for model entities to be constructed where android context is not available,
+        	// without ending on a RuntimeException
+        	if (instanciatedOnAndroid) {
+            		mTableInfo = Cache.getTableInfo(getClass());
+        	}
+    	}
 
 	//////////////////////////////////////////////////////////////////////////////////////
 	// PUBLIC METHODS


### PR DESCRIPTION
Hello there,
thanks for Active Android, we started using it for our new Android application. I have a proposal though, because I need to construct some of my Model instances in a web service outside of Android and then JSON-serialize them and send them over to an Android phone to be saved/updated/deleted. Take a look at the new constructor that I wrote to solve my problem. I don't want to leave it like this, because we want to easily upgrade to newer ActiveAndroid versions when available.
Feel free to propose a different solution if this is not an acceptable one.

Many thanks
Igor
