### PR TITLE
Add method in Table annotation for set column Id name.

### DIFF
--- a/src/com/activeandroid/TableInfo.java
+++ b/src/com/activeandroid/TableInfo.java
@@ -35,6 +35,7 @@ public final class TableInfo {
 
 	private Class<? extends Model> mType;
 	private String mTableName;
+	private String mIdName = Table.DEFAULT_ID_NAME;
 
 	private Map<Field, String> mColumnNames = new HashMap<Field, String>();
 
@@ -48,20 +49,22 @@ public final class TableInfo {
 		final Table tableAnnotation = type.getAnnotation(Table.class);
 		if (tableAnnotation != null) {
 			mTableName = tableAnnotation.name();
+			mIdName = tableAnnotation.id();
 		}
 		else {
 			mTableName = type.getSimpleName();
 		}
 
+		Field idField = getIdField(type);
+		mColumnNames.put(idField, mIdName);
 		List<Field> fields = new ArrayList<Field>(Arrays.asList(type.getDeclaredFields()));
-		fields.add(getIdField(type));
-
 		for (Field field : fields) {
 			if (field.isAnnotationPresent(Column.class)) {
 				final Column columnAnnotation = field.getAnnotation(Column.class);
 				mColumnNames.put(field, columnAnnotation.name());
 			}
 		}
+
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -74,6 +77,10 @@ public final class TableInfo {
 
 	public String getTableName() {
 		return mTableName;
+	}
+
+	public String getIdName() {
+		return mIdName;
 	}
 
 	public Collection<Field> getFields() {

--- a/src/com/activeandroid/annotation/Table.java
+++ b/src/com/activeandroid/annotation/Table.java
@@ -24,5 +24,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Table {
+
+	public static final String DEFAULT_ID_NAME = "Id";
 	public String name();
+	public String id() default DEFAULT_ID_NAME;
 }

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -152,30 +152,31 @@ public final class SQLiteUtils {
 		}
 
 		if (!TextUtils.isEmpty(definition)) {
-			if (column.length() > -1) {
-				definition.append("(");
-				definition.append(column.length());
-				definition.append(")");
-			}
 
-			if (name.equals("Id")) {
+			if (name.equals(tableInfo.getIdName())) {
 				definition.append(" PRIMARY KEY AUTOINCREMENT");
-			}
+			}else if(column!=null){
+				if (column.length() > -1) {
+					definition.append("(");
+					definition.append(column.length());
+					definition.append(")");
+				}
 
-			if (column.notNull()) {
-				definition.append(" NOT NULL ON CONFLICT ");
-				definition.append(column.onNullConflict().toString());
-			}
+				if (column.notNull()) {
+					definition.append(" NOT NULL ON CONFLICT ");
+					definition.append(column.onNullConflict().toString());
+				}
 
-			if (column.unique()) {
-				definition.append(" UNIQUE ON CONFLICT ");
-				definition.append(column.onUniqueConflict().toString());
+				if (column.unique()) {
+					definition.append(" UNIQUE ON CONFLICT ");
+					definition.append(column.onUniqueConflict().toString());
+				}
 			}
 
 			if (FOREIGN_KEYS_SUPPORTED && ReflectionUtils.isModel(type)) {
 				definition.append(" REFERENCES ");
 				definition.append(Cache.getTableInfo((Class<? extends Model>) type).getTableName());
-				definition.append("(Id)");
+				definition.append("("+tableInfo.getIdName()+")");
 				definition.append(" ON DELETE ");
 				definition.append(column.onDelete().toString().replace("_", " "));
 				definition.append(" ON UPDATE ");
@@ -191,6 +192,8 @@ public final class SQLiteUtils {
 
 	@SuppressWarnings("unchecked")
 	public static <T extends Model> List<T> processCursor(Class<? extends Model> type, Cursor cursor) {
+		TableInfo tableInfo = Cache.getTableInfo(type);
+		String idName = tableInfo.getIdName();
 		final List<T> entities = new ArrayList<T>();
 
 		try {
@@ -198,7 +201,7 @@ public final class SQLiteUtils {
 
 			if (cursor.moveToFirst()) {
 				do {
-					Model entity = Cache.getEntity(type, cursor.getLong(cursor.getColumnIndex("Id")));
+					Model entity = Cache.getEntity(type, cursor.getLong(cursor.getColumnIndex(idName)));
 					if (entity == null) {
 						entity = (T) entityConstructor.newInstance();
 					}

--- a/tests/src/com/activeandroid/test/MockModel.java
+++ b/tests/src/com/activeandroid/test/MockModel.java
@@ -19,6 +19,6 @@ package com.activeandroid.test;
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Table;
 
-@Table(name = "MockModel")
+@Table(name = "MockModel", id = "Id")
 public class MockModel extends Model {
 }

--- a/tests/src/com/activeandroid/test/query/FromTest.java
+++ b/tests/src/com/activeandroid/test/query/FromTest.java
@@ -156,11 +156,11 @@ public class FromTest extends SqlableTestCase {
 		return new Select().all().from(MockModel.class);
 	}
 	
-	@Table(name = "JoinModel")
+	@Table(name = "JoinModel", id = "Id")
 	private static class JoinModel extends Model {
 	}
 	
-	@Table(name = "JoinModel2")
+	@Table(name = "JoinModel2", id = "Id")
 	private static class JoinModel2 extends Model {
 	}
 }


### PR DESCRIPTION
Add method in Table annotation for set column Id name.

This fixes Issue #83

example:
@Table(name = "Items", id = BaseColumns._ID)
public class Item extends Model {...}
