### PR TITLE
FIx AA_MODEL meta-data bug

### DIFF
--- a/src/com/activeandroid/Configuration.java
+++ b/src/com/activeandroid/Configuration.java
@@ -255,7 +255,7 @@ public class Configuration {
 			final ClassLoader classLoader = mContext.getClass().getClassLoader();
 			for (String model : models) {
 				try {
-					Class modelClass = Class.forName(model, false, classLoader);
+					Class modelClass = Class.forName(model.trim(), false, classLoader);
 					if (ReflectionUtils.isModel(modelClass)) {
 						modelClasses.add(modelClass);
 					}
@@ -273,7 +273,7 @@ public class Configuration {
 			final ClassLoader classLoader = mContext.getClass().getClassLoader();
 			for (String serializer : serializers) {
 				try {
-					Class serializerClass = Class.forName(serializer, false, classLoader);
+					Class serializerClass = Class.forName(serializer.trim(), false, classLoader);
 					if (ReflectionUtils.isTypeSerializer(serializerClass)) {
 						typeSerializers.add(serializerClass);
 					}

--- a/src/com/activeandroid/Configuration.java
+++ b/src/com/activeandroid/Configuration.java
@@ -254,8 +254,6 @@ public class Configuration {
 			final List<Class<? extends Model>> modelClasses = new ArrayList<Class<? extends Model>>();
 			final ClassLoader classLoader = mContext.getClass().getClassLoader();
 			for (String model : models) {
-				model = ensurePackageInName(model);
-
 				try {
 					Class modelClass = Class.forName(model, false, classLoader);
 					if (ReflectionUtils.isModel(modelClass)) {
@@ -274,8 +272,6 @@ public class Configuration {
 			final List<Class<? extends TypeSerializer>> typeSerializers = new ArrayList<Class<? extends TypeSerializer>>();
 			final ClassLoader classLoader = mContext.getClass().getClassLoader();
 			for (String serializer : serializers) {
-				serializer = ensurePackageInName(serializer);
-
 				try {
 					Class serializerClass = Class.forName(serializer, false, classLoader);
 					if (ReflectionUtils.isTypeSerializer(serializerClass)) {
@@ -290,13 +286,5 @@ public class Configuration {
 			return typeSerializers;
 		}
 
-		private String ensurePackageInName(String name) {
-			String packageName = mContext.getPackageName();
-			if (name.startsWith(packageName)) {
-				return name.trim();
-			}
-
-			return packageName + name.trim();
-		}
 	}
 }

--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -77,21 +77,11 @@ final class ModelInfo {
 	}
 
 	public TableInfo getTableInfo(Class<? extends Model> type) {
-		TableInfo info = mTableInfos.get(type);
-		if (info == null) {
-			throw new RuntimeException("Failed to find table info for '" + type
-					+ "'. Did you define the class correctly in AndroidManifest meta-data tag?");
-		}
-		return info;
+		return mTableInfos.get(type);
 	}
 
 	public TypeSerializer getTypeSerializer(Class<?> type) {
-		TypeSerializer typeS = mTypeSerializers.get(type);
-		if (typeS == null) {
-			throw new RuntimeException("Failed to find serializer info for '" + type
-					+ "'. Did you define the class correctly in AndroidManifest meta-data tag?");
-		}
-		return typeS;
+		return mTypeSerializers.get(type);
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////

--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -77,11 +77,21 @@ final class ModelInfo {
 	}
 
 	public TableInfo getTableInfo(Class<? extends Model> type) {
-		return mTableInfos.get(type);
+		TableInfo info = mTableInfos.get(type);
+		if (info == null) {
+			throw new RuntimeException("Failed to find table info for '" + type
+					+ "'. Did you define the class correctly in AndroidManifest meta-data tag?");
+		}
+		return info;
 	}
 
 	public TypeSerializer getTypeSerializer(Class<?> type) {
-		return mTypeSerializers.get(type);
+		TypeSerializer typeS = mTypeSerializers.get(type);
+		if (typeS == null) {
+			throw new RuntimeException("Failed to find serializer info for '" + type
+					+ "'. Did you define the class correctly in AndroidManifest meta-data tag?");
+		}
+		return typeS;
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The mechanism for AA_MODEL was error-prone in that it assumed the
application package name would always match the src code package
name. This made it easier to define AA_MODEL classes by using
shortcut notation. Unfortunately, this is problematic when the
application package name differs from the src code package name,
which comes up most often with Gradle build variants where the
application package name changes on a build by build basis.
