### PR TITLE
Throw a runtime exception instead of silently failing when the

### DIFF
--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -210,6 +210,16 @@ public final class SQLiteUtils {
 			}
 
 		}
+		catch (NoSuchMethodException e) {
+			throw new RuntimeException(
+                "Your model " + type.getName() + " does not define a default " +
+                "constructor. The default constructor is required for " +
+                "now in ActiveAndroid models, as the process to " +
+                "populate the ORM model is : " +
+                "1. instantiate default model " +
+                "2. populate fields"
+            );
+		}
 		catch (Exception e) {
 			Log.e("Failed to process cursor.", e);
 		}


### PR DESCRIPTION
Hey guys so I'm a new user.

I just spent a few hours figuring out why a certain table was always returning 0 rows. Even though I kept inserting data to it.

Anyways, turns out it was a boneheaded move on my part: I created a model without a default constructor. The docs are pretty clear that it's required, however it was very easy to forget.

After tracing it back I found where the code fails when there's no default constructor, it gets caught by catch-all exception handler, and then possibly logged. I had started using a jar version I compiled separately (since I use eclipse) and logging was turned off by default, so I had no hints.

I went ahead and added a runtime exception that gets thrown in this scenario. I think the condition would only exist in development, and the hope is that it will help other new users that might run into the same problem.
