### PR TITLE
use configuration database version in onCreate to get correct current da...

### DIFF
--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -42,6 +42,12 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 
 	public final static String MIGRATION_PATH = "migrations";
 
+    //////////////////////////////////////////////////////////////////////////////////////
+    // PRIVATE VARIABLES
+    //////////////////////////////////////////////////////////////////////////////////////
+
+    private int mDatabaseVersion;
+
 	//////////////////////////////////////////////////////////////////////////////////////
 	// CONSTRUCTORS
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -49,6 +55,7 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 	public DatabaseHelper(Configuration configuration) {
 		super(configuration.getContext(), configuration.getDatabaseName(), null, configuration.getDatabaseVersion());
 		copyAttachedDatabase(configuration.getContext(), configuration.getDatabaseName());
+        mDatabaseVersion = configuration.getDatabaseVersion();
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -64,7 +71,7 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 	public void onCreate(SQLiteDatabase db) {
 		executePragmas(db);
 		executeCreate(db);
-		executeMigrations(db, -1, db.getVersion());
+		executeMigrations(db, -1, mDatabaseVersion);
 	}
 
 	@Override

--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -182,9 +182,18 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 			final InputStream input = Cache.getContext().getAssets().open(MIGRATION_PATH + "/" + file);
 			final BufferedReader reader = new BufferedReader(new InputStreamReader(input));
 			String line = null;
+            String insert = "";
 
 			while ((line = reader.readLine()) != null) {
-				db.execSQL(line.replace(";", ""));
+                if(line.endsWith(";")){
+                    insert += line;
+
+
+                    db.execSQL(insert.replace(";", ""));
+                    insert = "";
+                }else{
+                    insert += line + "\n";
+                }
 			}
 		}
 		catch (IOException e) {


### PR DESCRIPTION
With these changes the configuration.getDatabaseVersion() is used as the old db version when DatabaseHelper.onCreate() is called. Therefore, a migration sql file is executed in the onCreate method when it has the same name as defined in the AndroidManifest.xml (AA_DB_VERSION) and the mirgration files can be used to initialize the database with the use of a sql file.
