### PR TITLE
My compiler was not able to deal these casts by itself.

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -164,7 +164,7 @@ public abstract class Model {
 	}
 
 	public static <T extends Model> T load(Class<T> type, long id) {
-		return new Select().from(type).where("Id=?", id).executeSingle();
+		return (T) new Select().from(type).where("Id=?", id).executeSingle();
 	}
 
 	// Model population

--- a/src/com/activeandroid/query/From.java
+++ b/src/com/activeandroid/query/From.java
@@ -213,7 +213,7 @@ public final class From implements Sqlable {
 	public <T extends Model> T executeSingle() {
 		if (mQueryBase instanceof Select) {
 			limit(1);
-			return SQLiteUtils.rawQuerySingle(mType, toSql(), getArguments());
+			return (T) SQLiteUtils.rawQuerySingle(mType, toSql(), getArguments());
 		}
 		else {
 			SQLiteUtils.execSql(toSql(), getArguments());


### PR DESCRIPTION
After cloning this repository, I ran ant and in returning lines of these methods I got this exception:

"type parameters of <T>T cannot be determined; no unique maximal instance exists for type variable X with upper bounds..."

I don't know why it is happening, but after some googling I found out that this is a common error. Well, forcing the cast (unsafe) when returning seems to correct it.
