### PR TITLE
Fix incomplete cache entity when use the selection

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -170,12 +170,15 @@ public abstract class Model {
 	// Model population
 
 	public final void loadFromCursor(Cursor cursor) {
+		int sizeOfColumnNotFound = 0;
+
 		for (Field field : mTableInfo.getFields()) {
 			final String fieldName = mTableInfo.getColumnName(field);
 			Class<?> fieldType = field.getType();
 			final int columnIndex = cursor.getColumnIndex(fieldName);
 
 			if (columnIndex < 0) {
+				sizeOfColumnNotFound++;
 				continue;
 			}
 
@@ -263,7 +266,7 @@ public abstract class Model {
 			}
 		}
 
-		if (mId != null) {
+		if (mId != null && sizeOfColumnNotFound == 0) {
 			Cache.addEntity(this);
 		}
 	}


### PR DESCRIPTION
For example:

``` java
@Table(name = "Items")
public class Item extends Model {
    @Column(name = "Name")
    public String name;
    @Column(name = "Value")
    public String value;
}
```

``` java
Item firstItem = new Item();
firstItem.name = "first";
firstItem.value = "one";
firstItem.save();

Item firstItemWithIdAndNameColumnOnly = new Select("Id", "Name").from(Item.class).where("Name=?", "first").executeSingle();
// firstItemWithIdAndNameColumnOnly.value would be null right now, because the selection.

Item firstItemWithNoSelection = Item.load(Item.class, 1); // new Select().from(Item.class).where("Id=?", 1).executeSingle();
// firstItemWithNoSelection.value would be still null, because the first of items already been in the Cache.
```
