### PR TITLE
Make Column name optional.

### DIFF
--- a/src/com/activeandroid/TableInfo.java
+++ b/src/com/activeandroid/TableInfo.java
@@ -59,7 +59,11 @@ public final class TableInfo {
 		for (Field field : fields) {
 			if (field.isAnnotationPresent(Column.class)) {
 				final Column columnAnnotation = field.getAnnotation(Column.class);
-				mColumnNames.put(field, columnAnnotation.name());
+				String columnName = columnAnnotation.name();
+				if (columnName == null || columnName.isEmpty()) {
+					columnName = field.getName();
+				}
+				mColumnNames.put(field, columnName);
 			}
 		}
 	}

--- a/src/com/activeandroid/annotation/Column.java
+++ b/src/com/activeandroid/annotation/Column.java
@@ -1,4 +1,4 @@
-package com.activeandroid.annotation;
+ package com.activeandroid.annotation;
 
 /*
  * Copyright (C) 2010 Michael Pardo
@@ -32,7 +32,7 @@ public @interface Column {
 		SET_NULL, SET_DEFAULT, CASCADE, RESTRICT, NO_ACTION
 	}
 
-	public String name();
+	public String name() default "";
 
 	public int length() default -1;
 

--- a/src/com/activeandroid/annotation/Column.java
+++ b/src/com/activeandroid/annotation/Column.java
@@ -1,4 +1,4 @@
- package com.activeandroid.annotation;
+package com.activeandroid.annotation;
 
 /*
  * Copyright (C) 2010 Michael Pardo


### PR DESCRIPTION
I'm working in a large project with a number of different Models. The convention is to name the database column the same as the field name in the corresponding Model. This small change would relieve me from having to explicitly specify the name of the database column in the @Column annotation. If no name attribute is provided on the @Column annotation, it defaults to the name of the field in the Model.
