### PR TITLE
Add support for multiple indexes on a table

### DIFF
--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -126,8 +126,10 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 		db.beginTransaction();
 		try {
 			for (TableInfo tableInfo : Cache.getTableInfos()) {
-				String s = SQLiteUtils.createIndexDefinition(tableInfo);
-				if (!android.text.TextUtils.isEmpty(s)) db.execSQL(s);
+				List<String> definitions = SQLiteUtils.createIndexDefinitions(tableInfo);
+				for (String s : definitions) {
+					if (!android.text.TextUtils.isEmpty(s)) db.execSQL(s);
+				}
 			}
 			db.setTransactionSuccessful();
 		}

--- a/src/com/activeandroid/annotation/Column.java
+++ b/src/com/activeandroid/annotation/Column.java
@@ -72,4 +72,6 @@ public @interface Column {
 	public ConflictAction[] onUniqueConflicts() default {};
 
 	public boolean index() default false;
+	
+	public String[] indexGroups() default {};
 }

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -172,7 +173,7 @@ public final class SQLiteUtils {
 
 	public static List<String> createIndexDefinitions(TableInfo tableInfo) {
 		final List<String> definitions = new ArrayList<String>();
-		final Map<String, List<String>> indexColumns = new HashMap<String, List<String>>();
+		final Map<String, Set<String>> indexColumns = new HashMap<String, Set<String>>();
 		final String indexNameFormat = "index_%s_of_columns_%s_on_%s";
 		final String defaultIndexName = "default";
 		
@@ -181,9 +182,9 @@ public final class SQLiteUtils {
 
 			// Include columns where @Column.index = true in the default index
 			if (column.index()) {
-				List<String> columns = indexColumns.get(defaultIndexName);
+				Set<String> columns = indexColumns.get(defaultIndexName);
 				if (columns == null) {
-					columns = new ArrayList<String>();
+					columns = new HashSet<String>();
 				}
 
 				columns.add(tableInfo.getColumnName(field));
@@ -198,9 +199,9 @@ public final class SQLiteUtils {
 					continue;
 				}
 				
-				List<String> columns = indexColumns.get(namedIndex);
+				Set<String> columns = indexColumns.get(namedIndex);
 				if (columns == null) {
-					columns = new ArrayList<String>();
+					columns = new HashSet<String>();
 				}
 
 				columns.add(tableInfo.getColumnName(field));
@@ -210,7 +211,7 @@ public final class SQLiteUtils {
 
 		if (!indexColumns.isEmpty()) {
 			for (String indexName : indexColumns.keySet()) {
-				List<String> columns = indexColumns.get(indexName);
+				Set<String> columns = indexColumns.get(indexName);
 				if (!columns.isEmpty()) {
 					definitions.add(String.format("CREATE INDEX IF NOT EXISTS %s on %s(%s);",
 							String.format(indexNameFormat, indexName, TextUtils.join("_", columns), tableInfo.getTableName()),


### PR DESCRIPTION
Reworked #157 to add support for multiple indexes on a single table.

This update still supports the @Column.index attribute as before. It simply adds a new optional "indexGroups" attribute to the @Column annotation that takes a String array. If the indexGroups attribute is specified, all columns on a given table that have the same value in the indexGroups attribute will be added to a new named index where the name of the index is derived from the specified group.
