### PR TITLE
Return the row Id of the newly inserted row from Model.save

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -66,7 +66,7 @@ public abstract class Model {
 				.notifyChange(ContentProvider.createUri(mTableInfo.getType(), mId), null);
 	}
 
-	public final void save() {
+	public final Long save() {
 		final SQLiteDatabase db = Cache.openDatabase();
 		final ContentValues values = new ContentValues();
 
@@ -155,6 +155,7 @@ public abstract class Model {
 
 		Cache.getContext().getContentResolver()
 				.notifyChange(ContentProvider.createUri(mTableInfo.getType(), mId), null);
+		return mId;
 	}
 
 	// Convenience methods


### PR DESCRIPTION
Model.save relies on SQLiteDatabase.insert to perform the actual insert of a transient Model. Since the insert method on SQLiteDatabase returns the row ID of the newly inserted row (or -1 if an error occurred), Model.save might as well pass this along instead of discarding it. It can be useful when you create a transient model, persist it and then need to know the value the database automatically assigned to Id when it was inserted.

See http://developer.android.com/reference/android/database/sqlite/SQLiteDatabase.html.
