### PR TITLE
Avoid creating tables for abstract subclasses of Model

### DIFF
--- a/src/com/activeandroid/util/ReflectionUtils.java
+++ b/src/com/activeandroid/util/ReflectionUtils.java
@@ -16,6 +16,8 @@ package com.activeandroid.util;
  * limitations under the License.
  */
 
+import java.lang.reflect.Modifier;
+
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -29,7 +31,7 @@ public final class ReflectionUtils {
 	//////////////////////////////////////////////////////////////////////////////////////
 
 	public static boolean isModel(Class<?> type) {
-		return isSubclassOf(type, Model.class);
+		return isSubclassOf(type, Model.class) && (!Modifier.isAbstract(type.getModifiers()));
 	}
 
 	public static boolean isTypeSerializer(Class<?> type) {


### PR DESCRIPTION
If you've got a number of Models that share common functionality, you may want to factor that common functionality out into a superclass from which all your Models inherit. That superclass would be a subclass of com.activeandroid.Model (so that all your Models would still be ActiveAndroid Models) and would most likely be abstract (since it doesn't really represent an actual entity in your domain). In this case, you don't want a table to show up in your schema for the abstract superclass.

It seems to me that the easiest way to address this is to update the logic that determines if a class is a Model to exclude any class that is abstract. This seems consistent with the existing idea that in order to be a Model a class must provide a default constructor so that it can be instantiated and then populated.
