### PR TITLE
Allow disable foreign though field is Model

### DIFF
--- a/src/com/activeandroid/annotation/Column.java
+++ b/src/com/activeandroid/annotation/Column.java
@@ -40,6 +40,8 @@ public @interface Column {
 
 	public ConflictAction onNullConflict() default ConflictAction.FAIL;
 
+	public boolean foreign() default true;
+
 	public ForeignKeyAction onDelete() default ForeignKeyAction.NO_ACTION;
 
 	public ForeignKeyAction onUpdate() default ForeignKeyAction.NO_ACTION;

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -283,7 +283,7 @@ public final class SQLiteUtils {
 				definition.append(column.onUniqueConflict().toString());
 			}
 
-			if (FOREIGN_KEYS_SUPPORTED && ReflectionUtils.isModel(type)) {
+			if (FOREIGN_KEYS_SUPPORTED && ReflectionUtils.isModel(type) && column.foreign()) {
 				definition.append(" REFERENCES ");
 				definition.append(Cache.getTableInfo((Class<? extends Model>) type).getTableName());
 				definition.append("(Id)");


### PR DESCRIPTION
We would like to automatic recursive loading of foreign model, but we don't need it be a foreign key in SQLite scheme. Because the foreign key is slow on write in a huge table.

``` java
@Column(foreign = false)
public Item item;
```
