### PR TITLE
skip blank lines instead of throwing an exception

### DIFF
--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -195,7 +195,10 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 			String line = null;
 
 			while ((line = reader.readLine()) != null) {
-				db.execSQL(line.replace(";", ""));
+				line = line.replace(";", "").trim();
+				if (!line.isEmpty()) {
+					db.execSQL(line);
+				}
 			}
 		}
 		catch (IOException e) {


### PR DESCRIPTION
I noticed this issue when trying to run a migration with a SQL file that had blank lines. Android was throwing a strange error (the line numbers don't correspond to code in the master branch as I was using my own fork):

```
java.lang.RuntimeException: Unable to get provider com.activeandroid.content.ContentProvider: android.database.sqlite.SQLiteException: not an error (code 0)
   at android.app.ActivityThread.installProvider(ActivityThread.java:4882)
   at android.app.ActivityThread.installContentProviders(ActivityThread.java:4485)
   at android.app.ActivityThread.handleBindApplication(ActivityThread.java:4425)
   at android.app.ActivityThread.access$1300(ActivityThread.java:141)
   at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1316)
   at android.os.Handler.dispatchMessage(Handler.java:99)
   at android.os.Looper.loop(Looper.java:137)
   at android.app.ActivityThread.main(ActivityThread.java:5103)
   at java.lang.reflect.Method.invokeNative(Native Method)
   at java.lang.reflect.Method.invoke(Method.java:525)
   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:737)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
   at dalvik.system.NativeStart.main(Native Method)
Caused by: android.database.sqlite.SQLiteException: not an error (code 0)
   at android.database.sqlite.SQLiteConnection.nativeExecuteForChangedRowCount(Native Method)
   at android.database.sqlite.SQLiteConnection.executeForChangedRowCount(SQLiteConnection.java:734)
   at android.database.sqlite.SQLiteSession.executeForChangedRowCount(SQLiteSession.java:754)
   at android.database.sqlite.SQLiteStatement.executeUpdateDelete(SQLiteStatement.java:64)
   at android.database.sqlite.SQLiteDatabase.executeSql(SQLiteDatabase.java:1674)
   at android.database.sqlite.SQLiteDatabase.execSQL(SQLiteDatabase.java:1603)
   at com.activeandroid.DatabaseHelper.executeSqlScript(DatabaseHelper.java:198)
   at com.activeandroid.DatabaseHelper.executeMigrations(DatabaseHelper.java:168)
   at com.activeandroid.DatabaseHelper.onUpgrade(DatabaseHelper.java:75)
   at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:257)
   at android.database.sqlite.SQLiteOpenHelper.getWritableDatabase(SQLiteOpenHelper.java:164)
   at com.activeandroid.Cache.openDatabase(Cache.java:102)
   at com.activeandroid.Cache.initialize(Cache.java:75)
   at com.activeandroid.ActiveAndroid.initialize(ActiveAndroid.java:44)
   at com.activeandroid.ActiveAndroid.initialize(ActiveAndroid.java:34)
   at com.activeandroid.content.ContentProvider.onCreate(ContentProvider.java:39)
   at android.content.ContentProvider.attachInfo(ContentProvider.java:1214)
   at android.content.ContentProvider.attachInfo(ContentProvider.java:1189)
   at android.app.ActivityThread.installProvider(ActivityThread.java:4879)
   ... 12 more
```
