### PR TITLE
Cache is initialized

### DIFF
--- a/src/com/activeandroid/Cache.java
+++ b/src/com/activeandroid/Cache.java
@@ -97,6 +97,10 @@ public final class Cache {
 	}
 
 	// Database access
+	
+	public static boolean isInitialized() {
+		return sIsInitialized;
+	}
 
 	public static synchronized SQLiteDatabase openDatabase() {
 		return sDatabaseHelper.getWritableDatabase();


### PR DESCRIPTION
Added public `isInitialized()` method to `Cache`.

This probably isn't critical to production code scenarios. However, I have a number of unit tests for my ActiveAndroid-based application that were failing randomly because the tests were attempting to perform database operations before the ActiveAndroid framework was fully initialized. Forcing my tests to wait in `setUp()` until ActiveAndroid's `Cache` is fully initialized solved the problem for me.
