### PR TITLE
Fix it's not only delete single row when call Delete().executeSingle()

### DIFF
--- a/src/com/activeandroid/query/From.java
+++ b/src/com/activeandroid/query/From.java
@@ -219,7 +219,8 @@ public final class From implements Sqlable {
 			return (T) SQLiteUtils.rawQuerySingle(mType, toSql(), getArguments());
 		}
 		else {
-			SQLiteUtils.execSql(toSql(), getArguments());
+			limit(1);
+			SQLiteUtils.rawQuerySingle(mType, toSql(), getArguments()).delete();
 			return null;
 		}
 	}


### PR DESCRIPTION
It is a bug. When call

``` java
new Delete().from(Model.class).where().executeSingle();
```

It's not only delete single row. All rows that are satisfied with query condition will be deleted.
