### PR TITLE
Fix test suite.

### DIFF
--- a/tests/src/com/activeandroid/test/CacheTest.java
+++ b/tests/src/com/activeandroid/test/CacheTest.java
@@ -1,13 +1,13 @@
 package com.activeandroid.test;
 
+import android.test.AndroidTestCase;
+
 import com.activeandroid.ActiveAndroid;
 import com.activeandroid.Cache;
 import com.activeandroid.Configuration;
 import com.activeandroid.Model;
 import com.activeandroid.TableInfo;
 import com.activeandroid.annotation.Table;
-
-import android.test.AndroidTestCase;
 
 import java.util.Collection;
 

--- a/tests/src/com/activeandroid/test/CacheTest.java
+++ b/tests/src/com/activeandroid/test/CacheTest.java
@@ -16,6 +16,7 @@ public class CacheTest extends AndroidTestCase {
     @Override
     protected void setUp() {
         Configuration conf = new Configuration.Builder(getContext())
+                .setDatabaseName("CacheTest")
                 .addModelClasses(CacheTestModel.class, CacheTestModel2.class)
                 .create();
         ActiveAndroid.initialize(conf, true);

--- a/tests/src/com/activeandroid/test/MockModel.java
+++ b/tests/src/com/activeandroid/test/MockModel.java
@@ -19,6 +19,6 @@ package com.activeandroid.test;
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Table;
 
-@Table(name = "MockModel", id = "Id")
+@Table(name = "MockModel")
 public class MockModel extends Model {
 }

--- a/tests/src/com/activeandroid/test/ModelTest.java
+++ b/tests/src/com/activeandroid/test/ModelTest.java
@@ -18,10 +18,9 @@ package com.activeandroid.test;
 
 import com.activeandroid.Model;
 import com.activeandroid.annotation.Table;
+
 import java.util.HashSet;
 import java.util.Set;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
 
 /**
  * Simple test now covering equals and hashcode methods.
@@ -58,7 +57,7 @@ public class ModelTest extends ActiveAndroidTestCase {
 
 		assertFalse(model1.equals(model2));
 		assertFalse(model2.equals(model1));
-		assertTrue(model1.equals(model1));//equal only to itself
+		assertTrue(model1.equals(model1));  //equal only to itself
 	}
 
 	/**
@@ -73,10 +72,15 @@ public class ModelTest extends ActiveAndroidTestCase {
 		model2.save();
 		model3 = Model.load(MockModel.class, model1.getId());
 
+        // Not equal to each other.
 		assertFalse(model1.equals(model2));
 		assertFalse(model2.equals(model1));
+
+        // Equal to each other when loaded.
 		assertTrue(model1.equals(model3));
 		assertTrue(model1.equals(model3));
+
+        // Loaded model is not equal to a different model.
 		assertFalse(model3.equals(model2));
 		assertFalse(model2.equals(model3));
 	}

--- a/tests/src/com/activeandroid/test/query/FromTest.java
+++ b/tests/src/com/activeandroid/test/query/FromTest.java
@@ -166,11 +166,11 @@ public class FromTest extends SqlableTestCase {
 		return new Select().all().from(MockModel.class);
 	}
 	
-	@Table(name = "JoinModel", id = "Id")
+	@Table(name = "JoinModel")
 	private static class JoinModel extends Model {
 	}
 	
-	@Table(name = "JoinModel2", id = "Id")
+	@Table(name = "JoinModel2")
 	private static class JoinModel2 extends Model {
 	}
 }


### PR DESCRIPTION
- Use a different database name for CacheTest to prevent conflicts with the rest of the test suite.
- Removed manually setting id column for test models.
  - This inherently tests the default ID column name as well.
- Formatting, spacing and organized imports.
