### PR TITLE
Use new SQLiteUtils.lexSqlScript

### DIFF
--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -192,14 +192,20 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 		try {
 			final InputStream input = Cache.getContext().getAssets().open(MIGRATION_PATH + "/" + file);
 			final BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+
+			StringBuilder sb = new StringBuilder(255);
 			String line = null;
 
 			while ((line = reader.readLine()) != null) {
-				line = line.replace(";", "").trim();
-				if (!line.isEmpty()) {
-					db.execSQL(line);
+				sb.append(line).append('\n');
+			}
+
+			for (String s : SQLiteUtils.lexSqlScript(sb.toString())) {
+				if (!"\n".equals(s)) {
+					db.execSQL(s);
 				}
 			}
+
 		}
 		catch (IOException e) {
 			Log.e("Failed to execute " + file, e);

--- a/tests/src/com/activeandroid/test/SQLiteUtilsTest.java
+++ b/tests/src/com/activeandroid/test/SQLiteUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014 K.-M. Hansche.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.activeandroid.test;
+
+import java.util.List;
+
+import com.activeandroid.util.SQLiteUtils;
+
+public class SQLiteUtilsTest extends ActiveAndroidTestCase {
+
+	public void testLexSqlScript() {
+		final String s0 = "alter table a add(b int); alter table c add (d int);";
+		final String s1 = "alter table a add(b int); alter table c add (d int)";
+		final String s2 = "alter table a add(b varchar(255) default ';')";
+		final String s3 = "alter table a\nadd(b varchar(255) default ';')\n;";
+
+		List<String> l;
+		
+		l = SQLiteUtils.lexSqlScript(s0);
+		assertArrayEquals(l.toArray(), "alter table a add(b int)", " alter table c add (d int)");
+
+		l = SQLiteUtils.lexSqlScript(s1);
+		assertArrayEquals(l.toArray(), "alter table a add(b int)", " alter table c add (d int)");
+
+		l = SQLiteUtils.lexSqlScript(s2);
+		assertArrayEquals(l.toArray(), "alter table a add(b varchar(255) default ';')");
+		
+		l = SQLiteUtils.lexSqlScript(s3);
+		assertArrayEquals(l.toArray(), "alter table a\nadd(b varchar(255) default ';')\n");
+	}
+}


### PR DESCRIPTION
Actually use SQLiteUtils.lexSqlScript.

This is untested because I couldn’t get the recent AA to compile with my eclipse.

BTW, is there a compelling reason to not call BufferedReader.close() under android?
