### PR TITLE
Add support for count/exists queries.

### DIFF
--- a/src/com/activeandroid/query/From.java
+++ b/src/com/activeandroid/query/From.java
@@ -267,6 +267,10 @@ public final class From implements Sqlable {
         addFrom(sql);
         addJoins(sql);
         addWhere(sql);
+        addGroupBy(sql);
+        addHaving(sql);
+        addLimit(sql);
+        addOffset(sql);
 
         sql.append(")");
 

--- a/src/com/activeandroid/query/From.java
+++ b/src/com/activeandroid/query/From.java
@@ -34,7 +34,7 @@ public final class From implements Sqlable {
 	private Class<? extends Model> mType;
 	private String mAlias;
 	private List<Join> mJoins;
-	private String mWhere;
+	private final StringBuilder mWhere = new StringBuilder();
 	private String mGroupBy;
 	private String mHaving;
 	private String mOrderBy;
@@ -87,29 +87,41 @@ public final class From implements Sqlable {
 		return join;
 	}
 
-    public From where(String where) {
-        if (mWhere != null) {                                   // Chain conditions if a previous
-            mWhere = mWhere + " AND " + where;                  // condition exists.
-        } else {
-            mWhere = where;
+    public From where(String clause) {
+        // Chain conditions if a previous condition exists.
+        if (mWhere.length() > 0) {
+            mWhere.append(" AND ");
         }
-
+        mWhere.append(clause);
         return this;
     }
 
-    public From where(String where, Object... args) {
-        if (mWhere != null) {                                    // Chain conditions if a previous
-            mWhere = mWhere + " AND " + where;                   // condition exists.
-        }
-        else {
-            mWhere = where;
-        }
-
-        addArguments(args);
-
+    public From where(String clause, Object... args) {
+        where(clause).addArguments(args);
         return this;
     }
 
+    public From and(String clause) {
+        return where(clause);
+    }
+
+    public From and(String clause, Object... args) {
+        return where(clause, args);
+    }
+
+    public From or(String clause) {
+        if (mWhere.length() > 0) {
+            mWhere.append(" OR ");
+        }
+        mWhere.append(clause);
+        return this;
+    }
+
+    public From or(String clause, Object... args) {
+        or(clause).addArguments(args);
+        return this;
+    }
+    
 	public From groupBy(String groupBy) {
 		mGroupBy = groupBy;
 		return this;
@@ -144,85 +156,148 @@ public final class From implements Sqlable {
 	}
 
 	void addArguments(Object[] args) {
-        for( Object arg : args ) {
-            if (arg.getClass() == boolean.class || arg.getClass() == Boolean.class)
-                arg = ( arg.equals(true) ? 1 : 0 );
-
+        for(Object arg : args) {
+            if (arg.getClass() == boolean.class || arg.getClass() == Boolean.class) {
+                arg = (arg.equals(true) ? 1 : 0);
+            }
             mArguments.add(arg);
         }
 	}
 
-	@Override
-	public String toSql() {
-		StringBuilder sql = new StringBuilder();
-		sql.append(mQueryBase.toSql());
-		sql.append("FROM ");
-		sql.append(Cache.getTableName(mType)).append(" ");
+    private void addFrom(final StringBuilder sql) {
+        sql.append("FROM ");
+        sql.append(Cache.getTableName(mType)).append(" ");
 
-		if (mAlias != null) {
-			sql.append("AS ");
-			sql.append(mAlias);
-			sql.append(" ");
-		}
+        if (mAlias != null) {
+            sql.append("AS ");
+            sql.append(mAlias);
+            sql.append(" ");
+        }
+    }
 
-		for (Join join : mJoins) {
-			sql.append(join.toSql());
-		}
+    private void addJoins(final StringBuilder sql) {
+        for (final Join join : mJoins) {
+            sql.append(join.toSql());
+        }
+    }
 
-		if (mWhere != null) {
-			sql.append("WHERE ");
-			sql.append(mWhere);
-			sql.append(" ");
-		}
+    private void addWhere(final StringBuilder sql) {
+        if (mWhere.length() > 0) {
+            sql.append("WHERE ");
+            sql.append(mWhere);
+            sql.append(" ");
+        }
+    }
 
-		if (mGroupBy != null) {
-			sql.append("GROUP BY ");
-			sql.append(mGroupBy);
-			sql.append(" ");
-		}
+    private void addGroupBy(final StringBuilder sql) {
+        if (mGroupBy != null) {
+            sql.append("GROUP BY ");
+            sql.append(mGroupBy);
+            sql.append(" ");
+        }
+    }
 
-		if (mHaving != null) {
-			sql.append("HAVING ");
-			sql.append(mHaving);
-			sql.append(" ");
-		}
+    private void addHaving(final StringBuilder sql) {
+        if (mHaving != null) {
+            sql.append("HAVING ");
+            sql.append(mHaving);
+            sql.append(" ");
+        }
+    }
 
-		if (mOrderBy != null) {
-			sql.append("ORDER BY ");
-			sql.append(mOrderBy);
-			sql.append(" ");
-		}
+    private void addOrderBy(final StringBuilder sql) {
+        if (mOrderBy != null) {
+            sql.append("ORDER BY ");
+            sql.append(mOrderBy);
+            sql.append(" ");
+        }
+    }
 
-		if (mLimit != null) {
-			sql.append("LIMIT ");
-			sql.append(mLimit);
-			sql.append(" ");
-		}
+    private void addLimit(final StringBuilder sql) {
+        if (mLimit != null) {
+            sql.append("LIMIT ");
+            sql.append(mLimit);
+            sql.append(" ");
+        }
+    }
 
-		if (mOffset != null) {
-			sql.append("OFFSET ");
-			sql.append(mOffset);
-			sql.append(" ");
-		}
+    private void addOffset(final StringBuilder sql) {
+        if (mOffset != null) {
+            sql.append("OFFSET ");
+            sql.append(mOffset);
+            sql.append(" ");
+        }
+    }
 
-		// Don't wast time building the string
-		// unless we're going to log it.
-		if (Log.isEnabled()) {
-			Log.v(sql.toString() + " " + TextUtils.join(",", getArguments()));
-		}
+    private String sqlString(final StringBuilder sql) {
 
-		return sql.toString().trim();
-	}
+        final String sqlString = sql.toString().trim();
+
+        // Don't waste time building the string
+        // unless we're going to log it.
+        if (Log.isEnabled()) {
+            Log.v(sqlString + " " + TextUtils.join(",", getArguments()));
+        }
+
+        return sqlString;
+    }
+
+    @Override
+    public String toSql() {
+        final StringBuilder sql = new StringBuilder();
+        sql.append(mQueryBase.toSql());
+
+        addFrom(sql);
+        addJoins(sql);
+        addWhere(sql);
+        addGroupBy(sql);
+        addHaving(sql);
+        addOrderBy(sql);
+        addLimit(sql);
+        addOffset(sql);
+
+        return sqlString(sql);
+    }
+
+    public String toExistsSql() {
+
+        final StringBuilder sql = new StringBuilder();
+        sql.append("SELECT EXISTS(SELECT 1 ");
+
+        addFrom(sql);
+        addJoins(sql);
+        addWhere(sql);
+
+        sql.append(")");
+
+        return sqlString(sql);
+    }
+
+    public String toCountSql() {
+
+        final StringBuilder sql = new StringBuilder();
+        sql.append("SELECT COUNT(*) ");
+
+        addFrom(sql);
+        addJoins(sql);
+        addWhere(sql);
+        addGroupBy(sql);
+        addHaving(sql);
+        addLimit(sql);
+        addOffset(sql);
+
+        return sqlString(sql);
+    }
 
 	public <T extends Model> List<T> execute() {
 		if (mQueryBase instanceof Select) {
 			return SQLiteUtils.rawQuery(mType, toSql(), getArguments());
-		}
-		else {
+			
+		} else {
 			SQLiteUtils.execSql(toSql(), getArguments());
-			Cache.getContext().getContentResolver().notifyChange(ContentProvider
-					.createUri(mType, null), null);
+			Cache.getContext().getContentResolver().notifyChange(ContentProvider.createUri(mType, null), null);
 			return null;
+			
 		}
 	}
 
@@ -230,13 +305,29 @@ public final class From implements Sqlable {
 		if (mQueryBase instanceof Select) {
 			limit(1);
 			return (T) SQLiteUtils.rawQuerySingle(mType, toSql(), getArguments());
-		}
-		else {
+			
+		} else {
 			limit(1);
 			SQLiteUtils.rawQuerySingle(mType, toSql(), getArguments()).delete();
 			return null;
+			
 		}
 	}
+	
+    /**
+     * Gets a value indicating whether the query returns any rows.
+     * @return <code>true</code> if the query returns at least one row; otherwise, <code>false</code>.
+     */
+    public boolean exists() {
+        return SQLiteUtils.intQuery(toExistsSql(), getArguments()) != 0;
+    }
+
+    /**
+     * Gets the number of rows returned by the query.
+     */
+    public int count() {
+        return SQLiteUtils.intQuery(toCountSql(), getArguments());
+    }
 
 	public String[] getArguments() {
 		final int size = mArguments.size();

--- a/src/com/activeandroid/util/SQLiteUtils.java
+++ b/src/com/activeandroid/util/SQLiteUtils.java
@@ -106,6 +106,14 @@ public final class SQLiteUtils {
 
 		return entities;
 	}
+	  
+	public static int intQuery(final String sql, final String[] selectionArgs) {
+        final Cursor cursor = Cache.openDatabase().rawQuery(sql, selectionArgs);
+        final int number = processIntCursor(cursor);
+        cursor.close();
+
+        return number;
+	}
 
 	public static <T extends Model> T rawQuerySingle(Class<? extends Model> type, String sql, String[] selectionArgs) {
 		List<T> entities = rawQuery(type, sql, selectionArgs);
@@ -348,6 +356,13 @@ public final class SQLiteUtils {
 
 		return entities;
 	}
+
+	private static int processIntCursor(final Cursor cursor) {
+        if (cursor.moveToFirst()) {
+            return cursor.getInt(0);
+	    }
+        return 0;
+    }
 
 	public static List<String> lexSqlScript(String sqlScript) {
 		ArrayList<String> sl = new ArrayList<String>();

--- a/tests/src/com/activeandroid/test/query/CountTest.java
+++ b/tests/src/com/activeandroid/test/query/CountTest.java
@@ -65,9 +65,9 @@ public class CountTest extends SqlableTestCase {
 
         String actual = new Select()
                 .from(MockModel.class)
-                .groupBy("intField")
-                .orderBy("intField")
                 .where("intField <> ?", 0)
+                .orderBy("intField")
+                .groupBy("intField")
                 .toCountSql();
 
         assertEquals(expected, actual);
@@ -126,5 +126,44 @@ public class CountTest extends SqlableTestCase {
 
         assertEquals(0, count);
         assertEquals(list.size(), count);
+    }
+
+    /**
+     * Should not change the result if order by is used.
+     */
+    public void testCountOrderBy() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class)
+                .where("intField = ?", 1)
+                .orderBy("intField ASC");
+
+        final List<MockModel> list = from.execute();
+        final int count = from.count();
+
+        assertEquals(2, count);
+        assertEquals(list.size(), count);
+    }
+
+    /**
+     * Should return the total number of rows, even if the rows are grouped. May seem weird, just
+     * test it in an SQL explorer.
+     */
+    public void testCountGroupBy() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class)
+                .groupBy("intField")
+                .having("intField = 1");
+
+        final List<MockModel> list = from.execute();
+        final int count = from.count();
+
+        assertEquals(2, count);
+        assertEquals(1, list.size());
     }
 }

--- a/tests/src/com/activeandroid/test/query/CountTest.java
+++ b/tests/src/com/activeandroid/test/query/CountTest.java
@@ -1,0 +1,130 @@
+
+package com.activeandroid.test.query;
+
+import com.activeandroid.query.Delete;
+import com.activeandroid.query.From;
+import com.activeandroid.query.Select;
+import com.activeandroid.test.MockModel;
+
+import java.util.List;
+
+
+public class CountTest extends SqlableTestCase {
+
+    private void cleanTable() {
+        new Delete().from(MockModel.class).execute();
+    }
+
+    private void populateTable() {
+        MockModel m1 = new MockModel();
+        MockModel m2 = new MockModel();
+        MockModel m3 = new MockModel();
+
+        m1.intField = 1;
+        m2.intField = 1;
+        m3.intField = 2;
+
+        m1.save();
+        m2.save();
+        m3.save();
+    }
+
+    /**
+     * Should be a simple count for the entire table.
+     */
+    public void testCountTableSql() {
+        final String expected = "SELECT COUNT(*) FROM MockModel";
+
+        String actual = new Select()
+                .from(MockModel.class)
+                .toCountSql();
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Should be a count with the specified where-clause.
+     */
+    public void testCountWhereClauseSql() {
+        final String expected = "SELECT COUNT(*) FROM MockModel WHERE intField = ?";
+
+        String actual = new Select()
+                .from(MockModel.class)
+                .where("intField = ?", 1)
+                .toCountSql();
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Shouldn't include <i>order by</i> as it has no influence on the result of <i>count</i> and
+     * should improve performance.
+     */
+    public void testCountOrderBySql() {
+        final String expected = "SELECT COUNT(*) FROM MockModel WHERE intField <> ? GROUP BY intField";
+
+        String actual = new Select()
+                .from(MockModel.class)
+                .groupBy("intField")
+                .orderBy("intField")
+                .where("intField <> ?", 0)
+                .toCountSql();
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Should return the same count as there are entries in the result set/table.
+     */
+    public void testCountTable() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class);
+
+        final List<MockModel> list = from.execute();
+        final int count = from.count();
+
+        assertEquals(3, count);
+        assertEquals(list.size(), count);
+    }
+
+    /**
+     * Should return the same count as there are entries in the result set if the where-clause
+     * matches several entries.
+     */
+    public void testCountWhereClause() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class)
+                .where("intField = ?", 1);
+
+        final List<MockModel> list = from.execute();
+        final int count = from.count();
+
+        assertEquals(2, count);
+        assertEquals(list.size(), count);
+    }
+
+    /**
+     * Should return the same count as there are entries in the result set if the where-clause
+     * matches zero entries.
+     */
+    public void testCountEmptyResult() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class)
+                .where("intField = ?", 3);
+
+        final List<MockModel> list = from.execute();
+        final int count = from.count();
+
+        assertEquals(0, count);
+        assertEquals(list.size(), count);
+    }
+}

--- a/tests/src/com/activeandroid/test/query/ExistsTest.java
+++ b/tests/src/com/activeandroid/test/query/ExistsTest.java
@@ -1,0 +1,130 @@
+
+package com.activeandroid.test.query;
+
+import com.activeandroid.query.Delete;
+import com.activeandroid.query.From;
+import com.activeandroid.query.Select;
+import com.activeandroid.test.MockModel;
+
+import java.util.List;
+
+
+public class ExistsTest extends SqlableTestCase {
+
+    private void cleanTable() {
+        new Delete().from(MockModel.class).execute();
+    }
+
+    private void populateTable() {
+        MockModel m1 = new MockModel();
+        MockModel m2 = new MockModel();
+        MockModel m3 = new MockModel();
+
+        m1.intField = 1;
+        m2.intField = 1;
+        m3.intField = 2;
+
+        m1.save();
+        m2.save();
+        m3.save();
+    }
+
+    /**
+     * Should return {@code true} since the result set/table isn't empty.
+     */
+    public void testExistsTable() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class);
+
+        final List<MockModel> list = from.execute();
+        final boolean exists = from.exists();
+
+        assertTrue(exists);
+        assertTrue(list.size() > 0);
+    }
+
+    /**
+     * Should be a simple exists for the entire table.
+     */
+    public void testCountTableSql() {
+        final String expected = "SELECT EXISTS(SELECT 1 FROM MockModel )";
+
+        String actual = new Select()
+                .from(MockModel.class)
+                .toExistsSql();
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Should be an exists with the specified where-clause.
+     */
+    public void testCountWhereClauseSql() {
+        final String expected = "SELECT EXISTS(SELECT 1 FROM MockModel WHERE intField = ? )";
+
+        String actual = new Select()
+                .from(MockModel.class)
+                .where("intField = ?", 1)
+                .toExistsSql();
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Shouldn't include <i>group by</i> and <i>order by</i> as they has no influence on the result
+     * of <i>exists</i> and should improve performance.
+     */
+    public void testCountOrderBySql() {
+        final String expected = "SELECT EXISTS(SELECT 1 FROM MockModel WHERE intField <> ? )";
+
+        String actual = new Select()
+                .from(MockModel.class)
+                .groupBy("intField")
+                .orderBy("intField")
+                .where("intField <> ?", 0)
+                .toExistsSql();
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Should return {@code true} since the where-clause matches rows and thus the result set isn't
+     * empty.
+     */
+    public void testExistsWhereClause() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class)
+                .where("intField = ?", 1);
+
+        final List<MockModel> list = from.execute();
+        final boolean exists = from.exists();
+
+        assertTrue(exists);
+        assertTrue(list.size() > 0);
+    }
+
+    /**
+     * Should return {@code false} since the where-clause matches zero rows and thus the result set
+     * is empty.
+     */
+    public void testExistsEmptyResult() {
+        cleanTable();
+        populateTable();
+
+        From from = new Select()
+                .from(MockModel.class)
+                .where("intField = ?", 3);
+
+        final List<MockModel> list = from.execute();
+        final boolean exists = from.exists();
+
+        assertFalse(exists);
+        assertFalse(list.size() > 0);
+    }
+}

--- a/tests/src/com/activeandroid/test/query/FromTest.java
+++ b/tests/src/com/activeandroid/test/query/FromTest.java
@@ -85,6 +85,67 @@ public class FromTest extends SqlableTestCase {
 				query);
 	}
 
+	public void testWhereChaining() {
+	    
+	    From expected = from()
+	            .where("a = ? AND b = ?", 1, 2);
+	    
+	    From actual = from()
+	            .where("a = ?", 1, 2)
+	            .where("b = ?", 1, 2);
+	    
+	    assertSqlEquals(expected, actual);
+	}
+	
+   public void testWhereAndChaining() {
+
+       From expected = from()
+               .where("a = ? AND b = ?", 1, 2);
+
+       From actual = from()
+               .where("a = ?", 1)
+               .and("b = ?", 2);
+
+       assertSqlEquals(expected, actual);
+   }
+
+   public void testWhereOrChaining() {
+
+       From expected = from()
+               .where("a = ? OR b = ?", 1, 2);
+
+       From actual = from()
+               .where("a = ?", 1)
+               .or("b = ?", 2);
+
+       assertSqlEquals(expected, actual);
+   }
+
+   public void testWhereAndOrChaining() {
+
+       From expected = from()
+               .where("a = ? OR (b = ? AND c = ?)", 1, 2, 3);
+
+       From actual = from()
+               .where("a = ?", 1)
+               .or("(b = ? AND c = ?)", 2, 3);
+
+       assertSqlEquals(expected, actual);
+   }
+
+   public void testWhereAlternateAndOrChaining() {
+
+       From expected = from()
+               .where("a = ? OR (b = ? AND c = ?)", 1, 2, 3);
+
+       From actual = from()
+               .where("a = ?", 1)
+               .or("(b = ?", 2)
+               .and("c = ?)", 3);
+
+       assertSqlEquals(expected, actual);
+   }
+
     // Test with 'no arguments' and 'with arguments' chained together.
     public void testWhereWithNoArgumentsAndWithArguments() {
         From query = from().where("Id = 5");

--- a/tests/src/com/activeandroid/test/query/SqlableTestCase.java
+++ b/tests/src/com/activeandroid/test/query/SqlableTestCase.java
@@ -23,4 +23,8 @@ public abstract class SqlableTestCase extends ActiveAndroidTestCase {
 	public static void assertSqlEquals(String expected, Sqlable actual) {
 		assertEquals(expected, actual.toSql());
 	}
+	
+	public static void assertSqlEquals(Sqlable expected, Sqlable actual) {
+	    assertEquals(expected.toSql(), actual.toSql());
+	}
 }


### PR DESCRIPTION
This pull request adds support for both exists and count.

```
// Get the number of rows that match the where-clause
final int count = new Select()
                    .from(Entity.class)
                    .where("...")
                    .count();

// Get a boolean value that indicates if any rows exist that match the where-clause
final boolean exists = new Select()
                    .from(Entity.class)
                    .where("...")
                    .exists();
```
