### PR TITLE
Truncate method added to empty the full table and reset its id

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -163,6 +163,14 @@ public abstract class Model {
 
 	// Convenience methods
 
+    // Truncate fix
+    public static void truncate(Class<? extends Model> type){
+        TableInfo tableInfo = Cache.getTableInfo(type);
+        // Not the cleanest way, but...
+        ActiveAndroid.execSQL("delete from "+tableInfo.getTableName()+";");
+        ActiveAndroid.execSQL("delete from sqlite_sequence where name='"+tableInfo.getTableName()+"';");
+    }
+
 	public static void delete(Class<? extends Model> type, long id) {
 		TableInfo tableInfo = Cache.getTableInfo(type);
 		new Delete().from(type).where(tableInfo.getIdName()+"=?", id).execute();

--- a/tests/src/com/activeandroid/test/ModelTest.java
+++ b/tests/src/com/activeandroid/test/ModelTest.java
@@ -169,6 +169,28 @@ public class ModelTest extends ActiveAndroidTestCase {
         assertNull( new Select().from(MockModel.class).where("booleanField = ?", true).executeSingle() );
     }
 
+    /*
+    * Table truncation should delete all table's content and reset counter.
+    */
+    public void testTruncate(){
+        MockModel mockModel = new MockModel();
+        mockModel.save();
+
+        // Let's truncate table.
+        Model.truncate(MockModel.class);
+
+        // Table should have zero elements.
+        assertEquals( 0, new Select().from(MockModel.class).execute().size() );
+
+        // And generate another model
+        mockModel = new MockModel();
+        Long id = mockModel.save();
+
+        // This will tell us if ID's are equal (index have been reset).
+        assertEquals( id, new Long(1L) );
+    }
+
+
 	/**
 	 * Mock model as we need 2 different model classes.
 	 */


### PR DESCRIPTION
Viewing the issue #92, I've add a static method to Model to have a way to clear table contents and reset its incremental ID.

Solution is not very clean, I have use raw SQL and execSQL, but I could not find another way of doing this without modifying a lot of classes and structure (maybe add a sqlite_\* TableInfo?). Anyways I hope it helps (It have been tested with suite).
