### PR TITLE
Fix scanForModel method to avoid crash on load Models

### DIFF
--- a/src/com/activeandroid/Configuration.java
+++ b/src/com/activeandroid/Configuration.java
@@ -38,6 +38,7 @@ public class Configuration {
 	private Context mContext;
 	private String mDatabaseName;
 	private int mDatabaseVersion;
+    private Boolean mExcludeLibs;
 	private String mSqlParser;
 	private List<Class<? extends Model>> mModelClasses;
 	private List<Class<? extends TypeSerializer>> mTypeSerializers;
@@ -66,6 +67,8 @@ public class Configuration {
 	public int getDatabaseVersion() {
 		return mDatabaseVersion;
 	}
+
+    public Boolean getExcludeLibs() { return mExcludeLibs; }
 	
 	public String getSqlParser() {
 	    return mSqlParser;
@@ -101,10 +104,12 @@ public class Configuration {
 		private final static String AA_MODELS = "AA_MODELS";
 		private final static String AA_SERIALIZERS = "AA_SERIALIZERS";
 		private final static String AA_SQL_PARSER = "AA_SQL_PARSER";
+        private final static String AA_EXCLUDE_LIBS = "AA_EXCLUDE_LIBS";
 
 		private static final int DEFAULT_CACHE_SIZE = 1024;
 		private static final String DEFAULT_DB_NAME = "Application.db";
 		private static final String DEFAULT_SQL_PARSER = SQL_PARSER_LEGACY;
+        private static final Boolean DEFAULT_EXCLUDE_LIBS = false;
 
 		//////////////////////////////////////////////////////////////////////////////////////
 		// PRIVATE MEMBERS
@@ -116,6 +121,7 @@ public class Configuration {
 		private String mDatabaseName;
 		private Integer mDatabaseVersion;
 		private String mSqlParser;
+        private Boolean mExcludeLibs;
 		private List<Class<? extends Model>> mModelClasses;
 		private List<Class<? extends TypeSerializer>> mTypeSerializers;
 
@@ -141,6 +147,11 @@ public class Configuration {
 			mDatabaseName = databaseName;
 			return this;
 		}
+
+        public Builder setExcludeLibs(boolean excludeLibs) {
+            mExcludeLibs = excludeLibs;
+            return this;
+        }
 
 		public Builder setDatabaseVersion(int databaseVersion) {
 			mDatabaseVersion = databaseVersion;
@@ -222,7 +233,14 @@ public class Configuration {
 			} else {
 			    configuration.mSqlParser = getMetaDataSqlParserOrDefault();
 			}
-			
+
+            // Get the option of exclude libs to find models from meta-data
+            if (mExcludeLibs != null) {
+                configuration.mExcludeLibs = mExcludeLibs;
+            } else {
+                configuration.mExcludeLibs = getMetaDataExcludeLibsOrDefault();
+            }
+
 			// Get model classes from meta-data
 			if (mModelClasses != null) {
 				configuration.mModelClasses = mModelClasses;
@@ -269,6 +287,15 @@ public class Configuration {
 
 			return aaVersion;
 		}
+
+        private Boolean getMetaDataExcludeLibsOrDefault() {
+            Boolean aaExcludeLibs = ReflectionUtils.getMetaData(mContext, AA_EXCLUDE_LIBS);
+            if (aaExcludeLibs == null) {
+                aaExcludeLibs = DEFAULT_EXCLUDE_LIBS;
+            }
+
+            return aaExcludeLibs;
+        }
 
 		private String getMetaDataSqlParserOrDefault() {
 		    final String mode = ReflectionUtils.getMetaData(mContext, AA_SQL_PARSER);

--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -136,7 +136,7 @@ final class ModelInfo {
                 // Libs won't have models of ActiveRecord
                 String entry = entries.nextElement();
 
-                if(entry.startsWith(packageName) && !entry.endsWith("$1")) {
+                if(entry.startsWith(packageName)) {
                     paths.add(entry);
                 }
 			}

--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -60,7 +60,7 @@ final class ModelInfo {
 	public ModelInfo(Configuration configuration) {
 		if (!loadModelFromMetaData(configuration)) {
 			try {
-				scanForModel(configuration.getContext());
+				scanForModel(configuration.getContext(), configuration.getExcludeLibs());
 			}
 			catch (IOException e) {
 				Log.e("Couldn't open source path.", e);
@@ -121,7 +121,7 @@ final class ModelInfo {
 		return true;
 	}
 
-	private void scanForModel(Context context) throws IOException {
+	private void scanForModel(Context context, Boolean excludeLibs) throws IOException {
 		String packageName = context.getPackageName();
 		String sourcePath = context.getApplicationInfo().sourceDir;
 		List<String> paths = new ArrayList<String>();
@@ -132,11 +132,14 @@ final class ModelInfo {
 
 			while (entries.hasMoreElements()) {
 
-                // Check if the package starts with the correct packageName
-                // Libs won't have models of ActiveRecord
                 String entry = entries.nextElement();
 
-                if(entry.startsWith(packageName)) {
+                if(excludeLibs){
+                    // Check if the package starts with the correct packageName
+                    if(entry.startsWith(packageName)) {
+                        paths.add(entry);
+                    }
+                } else {
                     paths.add(entry);
                 }
 			}

--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -131,7 +131,14 @@ final class ModelInfo {
 			Enumeration<String> entries = dexfile.entries();
 
 			while (entries.hasMoreElements()) {
-				paths.add(entries.nextElement());
+
+                // Check if the package starts with the correct packageName
+                // Libs won't have models of ActiveRecord
+                String entry = entries.nextElement();
+
+                if(entry.startsWith(packageName) && !entry.endsWith("$1")) {
+                    paths.add(entry);
+                }
 			}
 		}
 		// Robolectric fallback


### PR DESCRIPTION
The scanForModel method added to paths var all the classes of the DexFile. Now, it only add the class that coincide with the package name of the user, so exclude the external libs like AndroidSupportLibrary. Before the change, paths var size was 3900 in my app. Now, it's size is 150.
