### PR TITLE
getManyThrough feature for base model

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -289,6 +289,17 @@ public abstract class Model {
 		return new Select().from(type).where(Cache.getTableName(type) + "." + foreignKey + "=?", getId()).execute();
 	}
 
+	protected final <T extends Model> List<T> getManyThrough(Class<T> targetClass, Class<T> joinClass, String targetForeignKeyInJoin, String foreignKeyInJoin){
+		return new Select()
+		.from(targetClass)
+		.as("target_model")
+		.join(joinClass)
+		.as("join_model")
+		.on("join_model." + targetForeignKeyInJoin + " = " + "target_model.id")
+		.where(foreignKeyInJoin + " = ?", this.getId())
+		.execute();
+	}
+
 	//////////////////////////////////////////////////////////////////////////////////////
 	// OVERRIDEN METHODS
 	//////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Get Many Through feature:
Similar to getMany method but for getting models related by a many-to-many relationship. It's necessary to specify the model that represents the join table and the colum names for foreign keys in that table. 
