### PR TITLE
catch NoClassDefFoundError when scanning for model classes

### DIFF
--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -204,6 +204,9 @@ final class ModelInfo {
 			catch (IllegalAccessException e) {
 				Log.e("IllegalAccessException", e);
 			}
+            catch (NoClassDefFoundError e) {
+                Log.e("NoClassDefFoundError", e);
+            }
 		}
 	}
 }


### PR DESCRIPTION
The dex file format has a limit of 65k method definitions. [It's easy to run into that limit](http://jakewharton.com/play-services-is-a-monolith/) when using common android libraries. One workaround is to [strip unused packages out of downloaded libraries when building](https://gist.github.com/dmarcato/d7c91b94214acd936e42). 

Unfortunately, if you do this, when ActiveAndroid initializes, it throws `NoClassDefFoundError`s for those packages when scanning for model classes. Here's a sample:

```
E/AndroidRuntime(28605): java.lang.NoClassDefFoundError: com.google.android.gms.internal.jf$1
E/AndroidRuntime(28605):    at java.lang.Class.classForName(Native Method)
E/AndroidRuntime(28605):    at java.lang.Class.forName(Class.java:305)
E/AndroidRuntime(28605):    at com.activeandroid.ModelInfo.scanForModelClasses(Unknown Source)
E/AndroidRuntime(28605):    at com.activeandroid.ModelInfo.scanForModel(Unknown Source)
E/AndroidRuntime(28605):    at com.activeandroid.ModelInfo.<init>(Unknown Source)
E/AndroidRuntime(28605):    at com.activeandroid.Cache.initialize(Unknown Source)
E/AndroidRuntime(28605):    at com.activeandroid.ActiveAndroid.initialize(Unknown Source)
E/AndroidRuntime(28605):    at com.activeandroid.ActiveAndroid.initialize(Unknown Source)
E/AndroidRuntime(28605):    at com.activeandroid.ActiveAndroid.initialize(Unknown Source)
```
