### PR TITLE
Added lifecycle events: preInsert(), preUpdate(), preSave(), and their postXY counterparts

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -70,8 +70,37 @@ public abstract class Model {
 		Cache.getContext().getContentResolver()
 				.notifyChange(ContentProvider.createUri(mTableInfo.getType(), mId), null);
 	}
-
+	
 	public final Long save() {
+        boolean isNew = (mId == null);
+
+        if (isNew) {
+            preInsert();
+        } else {
+            preUpdate();
+        }
+
+        preSave();
+        Long result = doSave();
+        postSave();
+
+        if (isNew) {
+            postInsert();
+        } else {
+            postUpdate();
+        }
+
+        return result;
+	}
+	
+	protected void preInsert() {}
+	protected void preUpdate() {}
+	protected void preSave() {}
+	protected void postSave() {}
+    protected void postInsert() {}
+    protected void postUpdate() {}
+
+	private final Long doSave() {
 		final SQLiteDatabase db = Cache.openDatabase();
 		final ContentValues values = new ContentValues();
 

--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -204,6 +204,9 @@ final class ModelInfo {
 			catch (IllegalAccessException e) {
 				Log.e("IllegalAccessException", e);
 			}
+            catch (IncompatibleClassChangeError e) {
+                Log.e("IncompatibleClassChangeError", e);
+            }
 		}
 	}
 }

--- a/src/com/activeandroid/annotation/Table.java
+++ b/src/com/activeandroid/annotation/Table.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Table {
 
-	public static final String DEFAULT_ID_NAME = "Id";
+	public static final String DEFAULT_ID_NAME = "id";
 	public String name();
 	public String id() default DEFAULT_ID_NAME;
 }


### PR DESCRIPTION
**preInsert()** & **postInsert()** are called only on **newly created** objects
**preUpdate()** & **postUpdate()** are called only on **already existing** objects
**preSave()** & **postSave()** are **always** called when saving an object
