### PR TITLE
Fix IncompatibleClassChangeError on Lollipop

### DIFF
--- a/src/com/activeandroid/ModelInfo.java
+++ b/src/com/activeandroid/ModelInfo.java
@@ -204,6 +204,9 @@ final class ModelInfo {
 			catch (IllegalAccessException e) {
 				Log.e("IllegalAccessException", e);
 			}
+			catch (IncompatibleClassChangeError e) {
+				Log.e("IncompatibleClassChangeError", e);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/pardom/ActiveAndroid/issues/337 by also catching IncompatibleClassChangeError when scanning for model classes
