### PR TITLE
insertOrThrow to provide information about errors

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -152,7 +152,7 @@ public abstract class Model {
 		}
 
 		if (mId == null) {
-			mId = db.insert(mTableInfo.getTableName(), null, values);
+			mId = db.insertOrThrow(mTableInfo.getTableName(), null, values);
 		}
 		else {
 			db.update(mTableInfo.getTableName(), values, idName+"=" + mId, null);

--- a/src/com/activeandroid/content/ContentProvider.java
+++ b/src/com/activeandroid/content/ContentProvider.java
@@ -1,8 +1,5 @@
 package com.activeandroid.content;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import android.content.ContentValues;
 import android.content.UriMatcher;
 import android.database.Cursor;
@@ -14,6 +11,9 @@ import com.activeandroid.Cache;
 import com.activeandroid.Configuration;
 import com.activeandroid.Model;
 import com.activeandroid.TableInfo;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ContentProvider extends android.content.ContentProvider {
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -93,7 +93,7 @@ public class ContentProvider extends android.content.ContentProvider {
 	@Override
 	public Uri insert(Uri uri, ContentValues values) {
 		final Class<? extends Model> type = getModelType(uri);
-		final Long id = Cache.openDatabase().insert(Cache.getTableName(type), null, values);
+		final Long id = Cache.openDatabase().insertOrThrow(Cache.getTableName(type), null, values);
 
 		if (id != null && id > 0) {
 			Uri retUri = createUri(type, id);


### PR DESCRIPTION
Currently if an insert fails, the developer is left guessing as to why.  If AA used insertOrThrow instead, there would be information about what happened.  If an app is relying on the current relatively silent failure of inserts, it may crash after this update.  The unfortunate thing is the exception thrown will be a runtime exception, so the compiler will not inform the dev that he needs to change anything.    However, I would argue that it's worth the risk to give developers the information they need to produce correct apps.  Currently I have a "debug save" version of the Model.save() method that doesn't actually do everything a save operation needs to do, but at least tells me what's going wrong with an insert.  So if I find a problem with an insert I have to switch to the debug method, and then switch back after fixing it.
