### PR TITLE
Workaround for #332 Save->delete->save not working.

### DIFF
--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -43,6 +43,7 @@ public abstract class Model {
 	//////////////////////////////////////////////////////////////////////////////////////
 
 	private Long mId = null;
+	private boolean deleted = false;
 
 	private final TableInfo mTableInfo;
 	private final String idName;
@@ -66,6 +67,7 @@ public abstract class Model {
 	public final void delete() {
 		Cache.openDatabase().delete(mTableInfo.getTableName(), idName+"=?", new String[] { getId().toString() });
 		Cache.removeEntity(this);
+		deleted = true;
 
 		Cache.getContext().getContentResolver()
 				.notifyChange(ContentProvider.createUri(mTableInfo.getType(), mId), null);
@@ -151,8 +153,9 @@ public abstract class Model {
 			}
 		}
 
-		if (mId == null) {
+		if (mId == null || deleted) {
 			mId = db.insert(mTableInfo.getTableName(), null, values);
+			deleted = false;
 		}
 		else {
 			db.update(mTableInfo.getTableName(), values, idName+"=" + mId, null);

--- a/src/com/activeandroid/Model.java
+++ b/src/com/activeandroid/Model.java
@@ -43,7 +43,7 @@ public abstract class Model {
 	//////////////////////////////////////////////////////////////////////////////////////
 
 	private Long mId = null;
-	private boolean deleted = false;
+	private boolean mDeleted = false;
 
 	private final TableInfo mTableInfo;
 	private final String idName;
@@ -67,7 +67,7 @@ public abstract class Model {
 	public final void delete() {
 		Cache.openDatabase().delete(mTableInfo.getTableName(), idName+"=?", new String[] { getId().toString() });
 		Cache.removeEntity(this);
-		deleted = true;
+		mDeleted = true;
 
 		Cache.getContext().getContentResolver()
 				.notifyChange(ContentProvider.createUri(mTableInfo.getType(), mId), null);
@@ -153,9 +153,9 @@ public abstract class Model {
 			}
 		}
 
-		if (mId == null || deleted) {
+		if (mId == null || mDeleted) {
 			mId = db.insert(mTableInfo.getTableName(), null, values);
-			deleted = false;
+			mDeleted = false;
 		}
 		else {
 			db.update(mTableInfo.getTableName(), values, idName+"=" + mId, null);


### PR DESCRIPTION
This solution preserves the original mId when the object is inserted again into the database, which is important for "undo" operations.
