### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
-compile 'com.michaelpardo:activeandroid:3.1.0-SNAPSHOT'
+implementation 'com.michaelpardo:activeandroid:3.1.0-SNAPSHOT'
 ```
 
 ## Documentation


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.