### PR TITLE
bugfix and set default sql parser

### DIFF
--- a/src/com/activeandroid/Configuration.java
+++ b/src/com/activeandroid/Configuration.java
@@ -104,7 +104,7 @@ public class Configuration {
 
 		private static final int DEFAULT_CACHE_SIZE = 1024;
 		private static final String DEFAULT_DB_NAME = "Application.db";
-		private static final String DEFAULT_SQL_PARSER = SQL_PARSER_LEGACY;
+		private static final String DEFAULT_SQL_PARSER = SQL_PARSER_DELIMITED;
 
 		//////////////////////////////////////////////////////////////////////////////////////
 		// PRIVATE MEMBERS

--- a/src/com/activeandroid/DatabaseHelper.java
+++ b/src/com/activeandroid/DatabaseHelper.java
@@ -49,6 +49,7 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
     // PRIVATE FIELDS
     //////////////////////////////////////////////////////////////////////////////////////
 
+    private Configuration mConfiguration;
     private final String mSqlParser;
 
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -59,6 +60,7 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 		super(configuration.getContext(), configuration.getDatabaseName(), null, configuration.getDatabaseVersion());
 		copyAttachedDatabase(configuration.getContext(), configuration.getDatabaseName());
 		mSqlParser = configuration.getSqlParser();
+		mConfiguration = configuration;
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////
@@ -73,15 +75,13 @@ public final class DatabaseHelper extends SQLiteOpenHelper {
 	@Override
 	public void onCreate(SQLiteDatabase db) {
 		executePragmas(db);
-		executeCreate(db);
-		executeMigrations(db, -1, db.getVersion());
+		executeMigrations(db, -1, mConfiguration.getDatabaseVersion());
 		executeCreateIndex(db);
 	}
 
 	@Override
 	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 		executePragmas(db);
-		executeCreate(db);
 		executeMigrations(db, oldVersion, newVersion);
 	}
 


### PR DESCRIPTION
In doc it says db tables is create and migrate by execute the
sql scripts in assets directory.
In fact in code the db table is create by the utilize the info of
annotated model class. 
SQLiteOpenHelper will set db version after
execute the onCreate, this will case the onCreate got the wrong db
version, and some migration sql script will never be executed.
I correct this by the first commit.

The second commit will set the default sql parser to "delimited". This will support multi-line sql script.
